### PR TITLE
Recommendations refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/kermieisinthehouse/gosx-notifier v0.1.1
 	github.com/kermieisinthehouse/systray v1.2.4
 	github.com/lucasb-eyer/go-colorful v1.2.0
+	github.com/spf13/cast v1.4.1
 	github.com/vearutop/statigz v1.1.6
 	github.com/vektah/gqlparser/v2 v2.4.1
 )
@@ -90,7 +91,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/zerolog v1.26.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/graphql/documents/data/config.graphql
+++ b/graphql/documents/data/config.graphql
@@ -185,4 +185,5 @@ fragment ConfigData on ConfigResult {
   defaults {
     ...ConfigDefaultSettingsData
   }
+  ui
 }

--- a/graphql/documents/mutations/config.graphql
+++ b/graphql/documents/mutations/config.graphql
@@ -40,12 +40,6 @@ mutation ConfigureUI($input: Map!) {
   configureUI(input: $input)
 }
 
-mutation ConfigureFrontPage($input: ConfigFrontPageInput!) {
-  configureFrontPage(input: $input) {
-    savedFilterIDs
-  }
-}
-
 mutation GenerateAPIKey($input: GenerateAPIKeyInput!) {
   generateAPIKey(input: $input)
 }

--- a/graphql/documents/mutations/config.graphql
+++ b/graphql/documents/mutations/config.graphql
@@ -36,6 +36,10 @@ mutation ConfigureDefaults($input: ConfigDefaultSettingsInput!) {
   }
 }
 
+mutation ConfigureUI($input: Map!) {
+  configureUI(input: $input)
+}
+
 mutation ConfigureFrontPage($input: ConfigFrontPageInput!) {
   configureFrontPage(input: $input) {
     savedFilterIDs

--- a/graphql/documents/queries/filter.graphql
+++ b/graphql/documents/queries/filter.graphql
@@ -1,3 +1,9 @@
+query FindSavedFilter($id: ID!) {
+  findSavedFilter(id: $id) {
+    ...SavedFilterData
+  }
+}
+
 query FindSavedFilters($mode: FilterMode) {
   findSavedFilters(mode: $mode) {
     ...SavedFilterData

--- a/graphql/documents/queries/filter.graphql
+++ b/graphql/documents/queries/filter.graphql
@@ -15,9 +15,3 @@ query FindDefaultFilter($mode: FilterMode!) {
     ...SavedFilterData
   }
 }
-
-query FindFrontPageFilters {
-  findFrontPageFilters {
-    ...SavedFilterData
-  }
-}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -4,8 +4,6 @@ type Query {
   findSavedFilter(id: ID!): SavedFilter
   findSavedFilters(mode: FilterMode): [SavedFilter!]!
   findDefaultFilter(mode: FilterMode!): SavedFilter
-  """Filters will be returned in the order to be displayed"""
-  findFrontPageFilters: [SavedFilter!]!
 
   """Find a scene by ID or Checksum"""
   findScene(id: ID, checksum: String): Scene
@@ -246,7 +244,6 @@ type Mutation {
   configureDLNA(input: ConfigDLNAInput!): ConfigDLNAResult!
   configureScraping(input: ConfigScrapingInput!): ConfigScrapingResult!
   configureDefaults(input: ConfigDefaultSettingsInput!): ConfigDefaultSettingsResult!
-  configureFrontPage(input: ConfigFrontPageInput!): ConfigFrontPageResult!
 
   # overwrites the entire UI configuration
   configureUI(input: Map!): Map!

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -247,6 +247,11 @@ type Mutation {
   configureDefaults(input: ConfigDefaultSettingsInput!): ConfigDefaultSettingsResult!
   configureFrontPage(input: ConfigFrontPageInput!): ConfigFrontPageResult!
 
+  # overwrites the entire UI configuration
+  configureUI(input: Map!): Map!
+  # sets a single UI key value
+  configureUISetting(key: String!, value: Any): Map!
+
   """Generate and set (or clear) API key"""
   generateAPIKey(input: GenerateAPIKeyInput!): String!
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1,6 +1,7 @@
 """The query root for this schema"""
 type Query {
   # Filters
+  findSavedFilter(id: ID!): SavedFilter
   findSavedFilters(mode: FilterMode): [SavedFilter!]!
   findDefaultFilter(mode: FilterMode!): SavedFilter
   """Filters will be returned in the order to be displayed"""

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -413,6 +413,7 @@ type ConfigResult {
   dlna: ConfigDLNAResult!
   scraping: ConfigScrapingResult!
   defaults: ConfigDefaultSettingsResult!
+  ui: Map!
 }
 
 """Directory structure of a path"""

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -444,11 +444,3 @@ type StashBoxValidationResult {
   valid: Boolean!
   status: String!
 }
-
-input ConfigFrontPageInput {
-  savedFilterIDs: [ID!]
-}
-
-type ConfigFrontPageResult {
-  savedFilterIDs: [ID!]!
-}

--- a/graphql/schema/types/scalars.graphql
+++ b/graphql/schema/types/scalars.graphql
@@ -5,3 +5,8 @@ It can be input as a RFC3339 string, or as "<4h" for "4 hours in the past" or ">
 for "5 minutes in the future"
 """
 scalar Timestamp
+
+# generic JSON object
+scalar Map
+
+scalar Any

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stashapp/stash/pkg/fsutil"
 	"github.com/stashapp/stash/pkg/logger"
 	"github.com/stashapp/stash/pkg/models"
-	"github.com/stashapp/stash/pkg/sliceutil/stringslice"
 )
 
 var ErrOverriddenConfig = errors.New("cannot set overridden value")
@@ -501,23 +500,6 @@ func (r *mutationResolver) GenerateAPIKey(ctx context.Context, input models.Gene
 	}
 
 	return newAPIKey, nil
-}
-
-func (r *mutationResolver) ConfigureFrontPage(ctx context.Context, input models.ConfigFrontPageInput) (*models.ConfigFrontPageResult, error) {
-	ids, err := stringslice.StringSliceToIntSlice(input.SavedFilterIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	c := config.GetInstance()
-	c.Set(config.FrontPageSavedFilterIDs, ids)
-	if err := c.Write(); err != nil {
-		return nil, err
-	}
-
-	return &models.ConfigFrontPageResult{
-		SavedFilterIDs: input.SavedFilterIDs,
-	}, nil
 }
 
 func (r *mutationResolver) ConfigureUI(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -519,3 +519,23 @@ func (r *mutationResolver) ConfigureFrontPage(ctx context.Context, input models.
 		SavedFilterIDs: input.SavedFilterIDs,
 	}, nil
 }
+
+func (r *mutationResolver) ConfigureUI(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
+	c := config.GetInstance()
+	c.Set(config.UI, input)
+
+	if err := c.Write(); err != nil {
+		return c.GetUIConfiguration(), err
+	}
+
+	return c.GetUIConfiguration(), nil
+}
+
+func (r *mutationResolver) ConfigureUISetting(ctx context.Context, key string, value interface{}) (map[string]interface{}, error) {
+	c := config.GetInstance()
+
+	cfg := c.GetUIConfiguration()
+	cfg[key] = value
+
+	return r.ConfigureUI(ctx, cfg)
+}

--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -522,7 +522,7 @@ func (r *mutationResolver) ConfigureFrontPage(ctx context.Context, input models.
 
 func (r *mutationResolver) ConfigureUI(ctx context.Context, input map[string]interface{}) (map[string]interface{}, error) {
 	c := config.GetInstance()
-	c.Set(config.UI, input)
+	c.SetUIConfiguration(input)
 
 	if err := c.Write(); err != nil {
 		return c.GetUIConfiguration(), err

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -66,6 +66,7 @@ func makeConfigResult() *models.ConfigResult {
 		Dlna:      makeConfigDLNAResult(),
 		Scraping:  makeConfigScrapingResult(),
 		Defaults:  makeConfigDefaultsResult(),
+		UI:        makeConfigUIResult(),
 	}
 }
 
@@ -214,6 +215,10 @@ func makeConfigDefaultsResult() *models.ConfigDefaultSettingsResult {
 		DeleteFile:      &deleteFileDefault,
 		DeleteGenerated: &deleteGeneratedDefault,
 	}
+}
+
+func makeConfigUIResult() map[string]interface{} {
+	return config.GetInstance().GetUIConfiguration()
 }
 
 func (r *queryResolver) ValidateStashBoxCredentials(ctx context.Context, input models.StashBoxInput) (*models.StashBoxValidationResult, error) {

--- a/internal/api/resolver_query_find_saved_filter.go
+++ b/internal/api/resolver_query_find_saved_filter.go
@@ -2,10 +2,26 @@ package api
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 )
+
+func (r *queryResolver) FindSavedFilter(ctx context.Context, id string) (ret *models.SavedFilter, err error) {
+	idInt, err := strconv.Atoi(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
+		ret, err = repo.SavedFilter().Find(idInt)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
 
 func (r *queryResolver) FindSavedFilters(ctx context.Context, mode *models.FilterMode) (ret []*models.SavedFilter, err error) {
 	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {

--- a/internal/api/resolver_query_find_saved_filter.go
+++ b/internal/api/resolver_query_find_saved_filter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/stashapp/stash/internal/manager/config"
 	"github.com/stashapp/stash/pkg/models"
 )
 
@@ -40,24 +39,6 @@ func (r *queryResolver) FindSavedFilters(ctx context.Context, mode *models.Filte
 func (r *queryResolver) FindDefaultFilter(ctx context.Context, mode models.FilterMode) (ret *models.SavedFilter, err error) {
 	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
 		ret, err = repo.SavedFilter().FindDefault(mode)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	return ret, err
-}
-
-func (r *queryResolver) FindFrontPageFilters(ctx context.Context) (ret []*models.SavedFilter, err error) {
-	c := config.GetInstance()
-
-	ids := c.GetFrontPageSavedFilterIDs()
-	if len(ids) == 0 {
-		return nil, nil
-	}
-
-	if err := r.withReadTxn(ctx, func(repo models.ReaderRepository) error {
-		const ignoreNotFound = true
-		ret, err = repo.SavedFilter().FindMany(ids, ignoreNotFound)
 		return err
 	}); err != nil {
 		return nil, err

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -153,8 +153,7 @@ const (
 	ImageLightboxScrollMode                 = "image_lightbox.scroll_mode"
 	ImageLightboxScrollAttemptsBeforeChange = "image_lightbox.scroll_attempts_before_change"
 
-	FrontPageSavedFilterIDs = "front_page.saved_filter_ids"
-	UI                      = "ui"
+	UI = "ui"
 
 	defaultImageLightboxSlideshowDelay = 5000
 
@@ -411,13 +410,6 @@ func (i *Instance) getStringSlice(key string) []string {
 	defer i.RUnlock()
 
 	return i.viper(key).GetStringSlice(key)
-}
-
-func (i *Instance) getIntSlice(key string) []int {
-	i.RLock()
-	defer i.RUnlock()
-
-	return i.viper(key).GetIntSlice(key)
 }
 
 func (i *Instance) getString(key string) string {
@@ -971,10 +963,6 @@ func (i *Instance) GetImageLightboxOptions() models.ConfigImageLightboxResult {
 	}
 
 	return ret
-}
-
-func (i *Instance) GetFrontPageSavedFilterIDs() []int {
-	return i.getIntSlice(FrontPageSavedFilterIDs)
 }
 
 func (i *Instance) GetDisableDropdownCreate() *models.ConfigDisableDropdownCreate {

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -154,6 +154,7 @@ const (
 	ImageLightboxScrollAttemptsBeforeChange = "image_lightbox.scroll_attempts_before_change"
 
 	FrontPageSavedFilterIDs = "front_page.saved_filter_ids"
+	UI                      = "ui"
 
 	defaultImageLightboxSlideshowDelay = 5000
 
@@ -982,6 +983,13 @@ func (i *Instance) GetDisableDropdownCreate() *models.ConfigDisableDropdownCreat
 		Studio:    i.getBool(DisableDropdownCreateStudio),
 		Tag:       i.getBool(DisableDropdownCreateTag),
 	}
+}
+
+func (i *Instance) GetUIConfiguration() map[string]interface{} {
+	i.RLock()
+	defer i.RUnlock()
+
+	return i.viper(UI).GetStringMap(UI)
 }
 
 func (i *Instance) GetCSSPath() string {

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -989,7 +989,20 @@ func (i *Instance) GetUIConfiguration() map[string]interface{} {
 	i.RLock()
 	defer i.RUnlock()
 
-	return i.viper(UI).GetStringMap(UI)
+	// HACK: viper changes map keys to case insensitive values, so the workaround is to
+	// convert map keys to snake case for storage
+	v := i.viper(UI).GetStringMap(UI)
+
+	return fromSnakeCaseMap(v)
+}
+
+func (i *Instance) SetUIConfiguration(v map[string]interface{}) {
+	i.RLock()
+	defer i.RUnlock()
+
+	// HACK: viper changes map keys to case insensitive values, so the workaround is to
+	// convert map keys to snake case for storage
+	i.viper(UI).Set(UI, toSnakeCaseMap(v))
 }
 
 func (i *Instance) GetCSSPath() string {

--- a/internal/manager/config/map.go
+++ b/internal/manager/config/map.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"bytes"
+	"unicode"
+
+	"github.com/spf13/cast"
+)
+
+// HACK: viper changes map keys to case insensitive values, so the workaround is to
+// convert the map to use snake-case keys
+
+// toSnakeCase converts a string to snake_case
+// NOTE: a double capital will be converted in a way that will yield a different result
+// when converted back to camel case.
+// For example: someIDs => some_ids => someIds
+func toSnakeCase(v string) string {
+	var buf bytes.Buffer
+	underscored := false
+	for i, c := range v {
+		if !underscored && unicode.IsUpper(c) && i > 0 {
+			buf.WriteByte('_')
+			underscored = true
+		} else {
+			underscored = false
+		}
+
+		buf.WriteRune(unicode.ToLower(c))
+	}
+	return buf.String()
+}
+
+func fromSnakeCase(v string) string {
+	var buf bytes.Buffer
+	cap := false
+	for i, c := range v {
+		switch {
+		case c == '_' && i > 0:
+			cap = true
+		case cap:
+			buf.WriteRune(unicode.ToUpper(c))
+			cap = false
+		default:
+			buf.WriteRune(c)
+		}
+	}
+	return buf.String()
+}
+
+// copyAndInsensitiviseMap behaves like insensitiviseMap, but creates a copy of
+// any map it makes case insensitive.
+func toSnakeCaseMap(m map[string]interface{}) map[string]interface{} {
+	nm := make(map[string]interface{})
+
+	for key, val := range m {
+		adjKey := toSnakeCase(key)
+		switch v := val.(type) {
+		case map[interface{}]interface{}:
+			nm[adjKey] = toSnakeCaseMap(cast.ToStringMap(v))
+		case map[string]interface{}:
+			nm[adjKey] = toSnakeCaseMap(v)
+		default:
+			nm[adjKey] = v
+		}
+	}
+
+	return nm
+}
+
+func fromSnakeCaseMap(m map[string]interface{}) map[string]interface{} {
+	nm := make(map[string]interface{})
+
+	for key, val := range m {
+		adjKey := fromSnakeCase(key)
+		switch v := val.(type) {
+		case map[interface{}]interface{}:
+			nm[adjKey] = fromSnakeCaseMap(cast.ToStringMap(v))
+		case map[string]interface{}:
+			nm[adjKey] = fromSnakeCaseMap(v)
+		default:
+			nm[adjKey] = v
+		}
+	}
+
+	return nm
+}

--- a/internal/manager/config/map_test.go
+++ b/internal/manager/config/map_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"testing"
+)
+
+func Test_toSnakeCase(t *testing.T) {
+	tests := []struct {
+		name string
+		v    string
+		want string
+	}{
+		{
+			"basic",
+			"basic",
+			"basic",
+		},
+		{
+			"two words",
+			"twoWords",
+			"two_words",
+		},
+		{
+			"three word value",
+			"threeWordValue",
+			"three_word_value",
+		},
+		{
+			"snake case",
+			"snake_case",
+			"snake_case",
+		},
+		{
+			"double capital",
+			"doubleCApital",
+			"double_capital",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toSnakeCase(tt.v); got != tt.want {
+				t.Errorf("toSnakeCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_fromSnakeCase(t *testing.T) {
+	tests := []struct {
+		name string
+		v    string
+		want string
+	}{
+		{
+			"basic",
+			"basic",
+			"basic",
+		},
+		{
+			"two words",
+			"two_words",
+			"twoWords",
+		},
+		{
+			"three word value",
+			"three_word_value",
+			"threeWordValue",
+		},
+		{
+			"camel case",
+			"camelCase",
+			"camelCase",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fromSnakeCase(tt.v); got != tt.want {
+				t.Errorf("fromSnakeCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/v2.5/src/components/FrontPage/Control.tsx
+++ b/ui/v2.5/src/components/FrontPage/Control.tsx
@@ -9,6 +9,7 @@ import * as GQL from "src/core/generated-graphql";
 import { useFindSavedFilter } from "src/core/StashService";
 import { ListFilterModel } from "src/models/list-filter/filter";
 import { GalleryRecommendationRow } from "../Galleries/GalleryRecommendationRow";
+import { ImageRecommendationRow } from "../Images/ImageRecommendationRow";
 import { MovieRecommendationRow } from "../Movies/MovieRecommendationRow";
 import { PerformerRecommendationRow } from "../Performers/PerformerRecommendationRow";
 import { SceneRecommendationRow } from "../Scenes/SceneRecommendationRow";
@@ -63,6 +64,14 @@ const RecommendationRow: React.FC<IFilter> = ({ mode, filter, header }) => {
     case GQL.FilterMode.Galleries:
       return (
         <GalleryRecommendationRow
+          isTouch={isTouch}
+          filter={filter}
+          header={header}
+        />
+      );
+    case GQL.FilterMode.Images:
+      return (
+        <ImageRecommendationRow
           isTouch={isTouch}
           filter={filter}
           header={header}

--- a/ui/v2.5/src/components/FrontPage/Control.tsx
+++ b/ui/v2.5/src/components/FrontPage/Control.tsx
@@ -1,0 +1,159 @@
+import React, { useMemo } from "react";
+import { useIntl } from "react-intl";
+import {
+  FrontPageContent,
+  ICustomFilter,
+  ISavedFilterRow,
+} from "src/core/config";
+import * as GQL from "src/core/generated-graphql";
+import { useFindSavedFilter } from "src/core/StashService";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import { GalleryRecommendationRow } from "../Galleries/GalleryRecommendationRow";
+import { MovieRecommendationRow } from "../Movies/MovieRecommendationRow";
+import { PerformerRecommendationRow } from "../Performers/PerformerRecommendationRow";
+import { SceneRecommendationRow } from "../Scenes/SceneRecommendationRow";
+import { StudioRecommendationRow } from "../Studios/StudioRecommendationRow";
+
+interface IFilter {
+  mode: GQL.FilterMode;
+  filter: ListFilterModel;
+  header: string;
+}
+
+const RecommendationRow: React.FC<IFilter> = ({ mode, filter, header }) => {
+  function isTouchEnabled() {
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  }
+
+  const isTouch = isTouchEnabled();
+
+  switch (mode) {
+    case GQL.FilterMode.Scenes:
+      return (
+        <SceneRecommendationRow
+          isTouch={isTouch}
+          filter={filter}
+          header={header}
+        />
+      );
+    case GQL.FilterMode.Studios:
+      return (
+        <StudioRecommendationRow
+          isTouch={isTouch}
+          filter={filter}
+          header={header}
+        />
+      );
+    case GQL.FilterMode.Movies:
+      return (
+        <MovieRecommendationRow
+          isTouch={isTouch}
+          filter={filter}
+          header={header}
+        />
+      );
+    case GQL.FilterMode.Performers:
+      return (
+        <PerformerRecommendationRow
+          isTouch={isTouch}
+          filter={filter}
+          header={header}
+        />
+      );
+    case GQL.FilterMode.Galleries:
+      return (
+        <GalleryRecommendationRow
+          isTouch={isTouch}
+          filter={filter}
+          header={header}
+        />
+      );
+    default:
+      return <></>;
+  }
+};
+
+interface ISavedFilterResults {
+  savedFilterID: string;
+}
+
+const SavedFilterResults: React.FC<ISavedFilterResults> = ({
+  savedFilterID,
+}) => {
+  const { loading, data } = useFindSavedFilter(savedFilterID.toString());
+
+  const filter = useMemo(() => {
+    if (!data?.findSavedFilter) return;
+
+    const { mode, filter: filterJSON } = data.findSavedFilter;
+
+    const ret = new ListFilterModel(mode);
+    ret.currentPage = 1;
+    ret.configureFromQueryParameters(JSON.parse(filterJSON));
+    ret.randomSeed = -1;
+    return ret;
+  }, [data?.findSavedFilter]);
+
+  if (loading || !data?.findSavedFilter || !filter) {
+    return <></>;
+  }
+
+  const { name, mode } = data.findSavedFilter;
+
+  return <RecommendationRow mode={mode} filter={filter} header={name} />;
+};
+
+interface ICustomFilterProps {
+  customFilter: ICustomFilter;
+}
+
+const CustomFilterResults: React.FC<ICustomFilterProps> = ({
+  customFilter,
+}) => {
+  const intl = useIntl();
+
+  const filter = useMemo(() => {
+    const itemsPerPage = 25;
+    const ret = new ListFilterModel(customFilter.mode);
+    ret.sortBy = customFilter.sortBy;
+    ret.sortDirection = customFilter.direction;
+    ret.itemsPerPage = itemsPerPage;
+    ret.currentPage = 1;
+    ret.randomSeed = -1;
+    return ret;
+  }, [customFilter]);
+
+  const header = customFilter.message
+    ? intl.formatMessage(
+        { id: customFilter.message.id },
+        customFilter.message.values
+      )
+    : customFilter.title ?? "";
+
+  return (
+    <RecommendationRow
+      mode={customFilter.mode}
+      filter={filter}
+      header={header}
+    />
+  );
+};
+
+interface IProps {
+  content: FrontPageContent;
+}
+
+export const Control: React.FC<IProps> = ({ content }) => {
+  switch (content.__typename) {
+    case "SavedFilter":
+      return (
+        <SavedFilterResults
+          savedFilterID={(content as ISavedFilterRow).savedFilterId.toString()}
+        />
+      );
+    case "CustomFilter":
+      return <CustomFilterResults customFilter={content as ICustomFilter} />;
+    default:
+      return <></>;
+  }
+};

--- a/ui/v2.5/src/components/FrontPage/FrontPage.tsx
+++ b/ui/v2.5/src/components/FrontPage/FrontPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { useConfigureUI } from "src/core/StashService";
 import { LoadingIndicator } from "src/components/Shared";
 import { Button } from "react-bootstrap";
@@ -14,6 +14,7 @@ import {
 } from "src/core/config";
 
 const FrontPage: React.FC = () => {
+  const intl = useIntl();
   const Toast = useToast();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -56,7 +57,7 @@ const FrontPage: React.FC = () => {
   const ui = (configuration?.ui ?? {}) as IUIConfig;
 
   if (!ui.frontPageContent) {
-    const defaultContent = generateDefaultFrontPageContent();
+    const defaultContent = generateDefaultFrontPageContent(intl);
     onUpdateConfig(defaultContent);
   }
 

--- a/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
+++ b/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
@@ -57,7 +57,7 @@ const AddContentModal: React.FC<IAddSavedFilterModalProps> = ({
   );
   const [premadeFilterIndex, setPremadeFilterIndex] = useState<
     number | undefined
-  >();
+  >(0);
   const [savedFilter, setSavedFilter] = useState<string | undefined>();
 
   function onTypeSelected(t: string) {

--- a/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
+++ b/ui/v2.5/src/components/FrontPage/FrontPageConfig.tsx
@@ -48,8 +48,8 @@ const AddContentModal: React.FC<IAddSavedFilterModalProps> = ({
   const intl = useIntl();
 
   const premadeFilterOptions = useMemo(
-    () => generatePremadeFrontPageContent(),
-    []
+    () => generatePremadeFrontPageContent(intl),
+    [intl]
   );
 
   const [contentType, setContentType] = useState(

--- a/ui/v2.5/src/components/FrontPage/styles.scss
+++ b/ui/v2.5/src/components/FrontPage/styles.scss
@@ -71,7 +71,8 @@
 
 .recommendations-container .studio-card hr,
 .recommendations-container .movie-card hr,
-.recommendations-container .gallery-card hr {
+.recommendations-container .gallery-card hr,
+.recommendations-container .image-card hr {
   margin-top: auto;
 }
 

--- a/ui/v2.5/src/components/Images/ImageCard.tsx
+++ b/ui/v2.5/src/components/Images/ImageCard.tsx
@@ -11,9 +11,9 @@ import { RatingBanner } from "../Shared/RatingBanner";
 interface IImageCardProps {
   image: GQL.SlimImageDataFragment;
   selecting?: boolean;
-  selected: boolean | undefined;
+  selected?: boolean | undefined;
   zoomIndex: number;
-  onSelectedChanged: (selected: boolean, shiftKey: boolean) => void;
+  onSelectedChanged?: (selected: boolean, shiftKey: boolean) => void;
   onPreview?: (ev: MouseEvent) => void;
 }
 

--- a/ui/v2.5/src/components/Images/ImageRecommendationRow.tsx
+++ b/ui/v2.5/src/components/Images/ImageRecommendationRow.tsx
@@ -25,7 +25,7 @@ export const ImageRecommendationRow: FunctionComponent<IProps> = (
 
   return (
     <RecommendationRow
-      className="gallery-recommendations"
+      className="images-recommendations"
       header={props.header}
       link={
         <a href={`/images?${props.filter.makeQueryParameters()}`}>
@@ -41,7 +41,7 @@ export const ImageRecommendationRow: FunctionComponent<IProps> = (
       >
         {result.loading
           ? [...Array(props.filter.itemsPerPage)].map((i) => (
-              <div key={i} className="gallery-skeleton skeleton-card"></div>
+              <div key={i} className="image-skeleton skeleton-card"></div>
             ))
           : result.data?.findImages.images.map((i) => (
               <ImageCard key={i.id} image={i} zoomIndex={1} />

--- a/ui/v2.5/src/components/Images/ImageRecommendationRow.tsx
+++ b/ui/v2.5/src/components/Images/ImageRecommendationRow.tsx
@@ -1,0 +1,52 @@
+import React, { FunctionComponent } from "react";
+import { useFindImages } from "src/core/StashService";
+import Slider from "react-slick";
+import { ListFilterModel } from "src/models/list-filter/filter";
+import { getSlickSliderSettings } from "src/core/recommendations";
+import { RecommendationRow } from "../FrontPage/RecommendationRow";
+import { FormattedMessage } from "react-intl";
+import { ImageCard } from "./ImageCard";
+
+interface IProps {
+  isTouch: boolean;
+  filter: ListFilterModel;
+  header: String;
+}
+
+export const ImageRecommendationRow: FunctionComponent<IProps> = (
+  props: IProps
+) => {
+  const result = useFindImages(props.filter);
+  const cardCount = result.data?.findImages.count;
+
+  if (!result.loading && !cardCount) {
+    return null;
+  }
+
+  return (
+    <RecommendationRow
+      className="gallery-recommendations"
+      header={props.header}
+      link={
+        <a href={`/images?${props.filter.makeQueryParameters()}`}>
+          <FormattedMessage id="view_all" />
+        </a>
+      }
+    >
+      <Slider
+        {...getSlickSliderSettings(
+          cardCount ? cardCount : props.filter.itemsPerPage,
+          props.isTouch
+        )}
+      >
+        {result.loading
+          ? [...Array(props.filter.itemsPerPage)].map((i) => (
+              <div key={i} className="gallery-skeleton skeleton-card"></div>
+            ))
+          : result.data?.findImages.images.map((i) => (
+              <ImageCard key={i.id} image={i} zoomIndex={1} />
+            ))}
+      </Slider>
+    </RecommendationRow>
+  );
+};

--- a/ui/v2.5/src/components/Scenes/SceneRecommendationRow.tsx
+++ b/ui/v2.5/src/components/Scenes/SceneRecommendationRow.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useMemo } from "react";
 import { useFindScenes } from "src/core/StashService";
 import Slider from "react-slick";
 import { SceneCard } from "./SceneCard";
@@ -11,7 +11,6 @@ import { FormattedMessage } from "react-intl";
 interface IProps {
   isTouch: boolean;
   filter: ListFilterModel;
-  queue: SceneQueue;
   header: String;
 }
 
@@ -20,6 +19,10 @@ export const SceneRecommendationRow: FunctionComponent<IProps> = (
 ) => {
   const result = useFindScenes(props.filter);
   const cardCount = result.data?.findScenes.count;
+
+  const queue = useMemo(() => {
+    return SceneQueue.fromListFilterModel(props.filter);
+  }, [props.filter]);
 
   if (!result.loading && !cardCount) {
     return null;
@@ -49,7 +52,7 @@ export const SceneRecommendationRow: FunctionComponent<IProps> = (
               <SceneCard
                 key={scene.id}
                 scene={scene}
-                queue={props.queue}
+                queue={queue}
                 index={index}
                 zoomIndex={1}
               />

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -44,6 +44,13 @@ const deleteCache = (queries: DocumentNode[]) => {
     });
 };
 
+export const useFindSavedFilter = (id: string) =>
+  GQL.useFindSavedFilterQuery({
+    variables: {
+      id,
+    },
+  });
+
 export const useFindSavedFilters = (mode?: GQL.FilterMode) =>
   GQL.useFindSavedFiltersQuery({
     variables: {
@@ -812,6 +819,12 @@ export const useGenerateAPIKey = () =>
 
 export const useConfigureDefaults = () =>
   GQL.useConfigureDefaultsMutation({
+    refetchQueries: getQueryNames([GQL.ConfigurationDocument]),
+    update: deleteCache([GQL.ConfigurationDocument]),
+  });
+
+export const useConfigureUI = () =>
+  GQL.useConfigureUiMutation({
     refetchQueries: getQueryNames([GQL.ConfigurationDocument]),
     update: deleteCache([GQL.ConfigurationDocument]),
   });

--- a/ui/v2.5/src/core/StashService.ts
+++ b/ui/v2.5/src/core/StashService.ts
@@ -58,9 +58,6 @@ export const useFindSavedFilters = (mode?: GQL.FilterMode) =>
     },
   });
 
-export const useFindFrontPageFiltersQuery = () =>
-  GQL.useFindFrontPageFiltersQuery();
-
 export const useFindDefaultFilter = (mode: GQL.FilterMode) =>
   GQL.useFindDefaultFilterQuery({
     variables: {
@@ -851,12 +848,6 @@ export const useConfigureScraping = () =>
   GQL.useConfigureScrapingMutation({
     refetchQueries: getQueryNames([GQL.ConfigurationDocument]),
     update: deleteCache([GQL.ConfigurationDocument]),
-  });
-
-export const useConfigureFrontPage = () =>
-  GQL.useConfigureFrontPageMutation({
-    refetchQueries: getQueryNames([GQL.FindFrontPageFiltersDocument]),
-    update: deleteCache([GQL.FindFrontPageFiltersDocument]),
   });
 
 export const querySystemStatus = () =>

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -64,6 +64,7 @@ export function generatePremadeFrontPageContent() {
     recentlyAdded(FilterMode.Scenes, "scenes"),
     recentlyReleased(FilterMode.Galleries, "galleries"),
     recentlyAdded(FilterMode.Galleries, "galleries"),
+    recentlyAdded(FilterMode.Images, "images"),
     recentlyReleased(FilterMode.Movies, "movies"),
     recentlyAdded(FilterMode.Movies, "movies"),
     recentlyAdded(FilterMode.Studios, "studios"),

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -1,0 +1,72 @@
+import { ITypename } from "src/utils";
+import { FilterMode, SortDirectionEnum } from "./generated-graphql";
+
+// NOTE: double capitals aren't converted correctly in the backend
+
+export interface ISavedFilterRow extends ITypename {
+  __typename: "SavedFilter";
+  savedFilterId: number;
+}
+
+export interface IMessage {
+  id: string;
+  values: { [key: string]: string };
+}
+
+export interface ICustomFilter extends ITypename {
+  __typename: "CustomFilter";
+  message?: IMessage;
+  title?: string;
+  mode: FilterMode;
+  sortBy: string;
+  direction: SortDirectionEnum;
+}
+
+export type FrontPageContent = ISavedFilterRow | ICustomFilter;
+
+export interface IUIConfig {
+  frontPageContent?: FrontPageContent[];
+}
+
+function recentlyReleased(mode: FilterMode, objects: string): ICustomFilter {
+  return {
+    __typename: "CustomFilter",
+    message: { id: "recently_released_objects", values: { objects } },
+    mode,
+    sortBy: "date",
+    direction: SortDirectionEnum.Desc,
+  };
+}
+
+function recentlyAdded(mode: FilterMode, objects: string): ICustomFilter {
+  return {
+    __typename: "CustomFilter",
+    message: { id: "recently_added_objects", values: { objects } },
+    mode,
+    sortBy: "created_at",
+    direction: SortDirectionEnum.Desc,
+  };
+}
+
+export function generateDefaultFrontPageContent() {
+  return [
+    recentlyReleased(FilterMode.Scenes, "scenes"),
+    recentlyAdded(FilterMode.Studios, "studios"),
+    recentlyReleased(FilterMode.Movies, "movies"),
+    recentlyAdded(FilterMode.Performers, "performers"),
+    recentlyReleased(FilterMode.Galleries, "galleries"),
+  ];
+}
+
+export function generatePremadeFrontPageContent() {
+  return [
+    recentlyReleased(FilterMode.Scenes, "scenes"),
+    recentlyAdded(FilterMode.Scenes, "scenes"),
+    recentlyReleased(FilterMode.Galleries, "galleries"),
+    recentlyAdded(FilterMode.Galleries, "galleries"),
+    recentlyReleased(FilterMode.Movies, "movies"),
+    recentlyAdded(FilterMode.Movies, "movies"),
+    recentlyAdded(FilterMode.Studios, "studios"),
+    recentlyAdded(FilterMode.Performers, "performers"),
+  ];
+}

--- a/ui/v2.5/src/core/config.ts
+++ b/ui/v2.5/src/core/config.ts
@@ -1,3 +1,4 @@
+import { IntlShape } from "react-intl";
 import { ITypename } from "src/utils";
 import { FilterMode, SortDirectionEnum } from "./generated-graphql";
 
@@ -28,46 +29,60 @@ export interface IUIConfig {
   frontPageContent?: FrontPageContent[];
 }
 
-function recentlyReleased(mode: FilterMode, objects: string): ICustomFilter {
+function recentlyReleased(
+  intl: IntlShape,
+  mode: FilterMode,
+  objectsID: string
+): ICustomFilter {
   return {
     __typename: "CustomFilter",
-    message: { id: "recently_released_objects", values: { objects } },
+    message: {
+      id: "recently_released_objects",
+      values: { objects: intl.formatMessage({ id: objectsID }) },
+    },
     mode,
     sortBy: "date",
     direction: SortDirectionEnum.Desc,
   };
 }
 
-function recentlyAdded(mode: FilterMode, objects: string): ICustomFilter {
+function recentlyAdded(
+  intl: IntlShape,
+  mode: FilterMode,
+  objectsID: string
+): ICustomFilter {
   return {
     __typename: "CustomFilter",
-    message: { id: "recently_added_objects", values: { objects } },
+    message: {
+      id: "recently_added_objects",
+      values: { objects: intl.formatMessage({ id: objectsID }) },
+    },
     mode,
     sortBy: "created_at",
     direction: SortDirectionEnum.Desc,
   };
 }
 
-export function generateDefaultFrontPageContent() {
+export function generateDefaultFrontPageContent(intl: IntlShape) {
   return [
-    recentlyReleased(FilterMode.Scenes, "scenes"),
-    recentlyAdded(FilterMode.Studios, "studios"),
-    recentlyReleased(FilterMode.Movies, "movies"),
-    recentlyAdded(FilterMode.Performers, "performers"),
-    recentlyReleased(FilterMode.Galleries, "galleries"),
+    recentlyReleased(intl, FilterMode.Scenes, "scenes"),
+    recentlyAdded(intl, FilterMode.Studios, "studios"),
+    recentlyReleased(intl, FilterMode.Movies, "movies"),
+    recentlyAdded(intl, FilterMode.Performers, "performers"),
+    recentlyReleased(intl, FilterMode.Galleries, "galleries"),
   ];
 }
 
-export function generatePremadeFrontPageContent() {
+export function generatePremadeFrontPageContent(intl: IntlShape) {
   return [
-    recentlyReleased(FilterMode.Scenes, "scenes"),
-    recentlyAdded(FilterMode.Scenes, "scenes"),
-    recentlyReleased(FilterMode.Galleries, "galleries"),
-    recentlyAdded(FilterMode.Galleries, "galleries"),
-    recentlyAdded(FilterMode.Images, "images"),
-    recentlyReleased(FilterMode.Movies, "movies"),
-    recentlyAdded(FilterMode.Movies, "movies"),
-    recentlyAdded(FilterMode.Studios, "studios"),
-    recentlyAdded(FilterMode.Performers, "performers"),
+    recentlyReleased(intl, FilterMode.Scenes, "scenes"),
+    recentlyAdded(intl, FilterMode.Scenes, "scenes"),
+    recentlyReleased(intl, FilterMode.Galleries, "galleries"),
+    recentlyAdded(intl, FilterMode.Galleries, "galleries"),
+    recentlyAdded(intl, FilterMode.Images, "images"),
+    recentlyReleased(intl, FilterMode.Movies, "movies"),
+    recentlyAdded(intl, FilterMode.Movies, "movies"),
+    recentlyAdded(intl, FilterMode.Studios, "studios"),
+    recentlyAdded(intl, FilterMode.Performers, "performers"),
   ];
 }

--- a/ui/v2.5/src/locales/en-GB.json
+++ b/ui/v2.5/src/locales/en-GB.json
@@ -734,6 +734,12 @@
   "filters": "Filters",
   "framerate": "Frame Rate",
   "frames_per_second": "{value} frames per second",
+  "front_page": {
+    "types": {
+      "premade_filter": "Premade Filter",
+      "saved_filter": "Saved Filter"
+    }
+  },
   "galleries": "Galleries",
   "gallery": "Gallery",
   "gallery_count": "Gallery Count",
@@ -826,11 +832,8 @@
   "queue": "Queue",
   "random": "Random",
   "rating": "Rating",
-  "recently_added_performers": "Recently Added Performers",
-  "recently_added_studios": "Recently Added Studios",
-  "recently_released_galleries": "Recently Released Galleries",
-  "recently_released_movies": "Recently Released Movies",
-  "recently_released_scenes": "Recently Released Scenes",
+  "recently_added_objects": "Recently Added {objects}",
+  "recently_released_objects": "Recently Released {objects}",
   "resolution": "Resolution",
   "scene": "Scene",
   "sceneTagger": "Scene Tagger",
@@ -967,6 +970,7 @@
   "total": "Total",
   "true": "True",
   "twitter": "Twitter",
+  "type": "Type",
   "updated_at": "Updated At",
   "url": "URL",
   "videos": "Videos",

--- a/ui/v2.5/src/utils/data.ts
+++ b/ui/v2.5/src/utils/data.ts
@@ -1,7 +1,7 @@
 export const filterData = <T>(data?: (T | null | undefined)[] | null) =>
   data ? (data.filter((item) => item) as T[]) : [];
 
-interface ITypename {
+export interface ITypename {
   __typename?: string;
 }
 


### PR DESCRIPTION
- Changes the front page configuration to use a new `ui` settings interface. The backend shouldn't care about these UI-specific options, so adding a UI-specific interface that wasn't strictly graphql type-based seemed like the way to go, and will make it easier to extend this system in the future.
- Extends the supported "widget" types to include "pre-made" filters. These are a replacement for the existing hard-coded ones that appear initially.
- Changed the initial behaviour so that if there is no existing front page config value, then it is pre-populated based on the original hard-coded rows. These can then be customised by the user.
- Removed the old front page config interfaces.