### PR TITLE
Feature/facet extensions wrap up

### DIFF
--- a/graphql/schema/types/facets.graphql
+++ b/graphql/schema/types/facets.graphql
@@ -143,6 +143,8 @@ type GroupFacetsResult {
   performers: [FacetCount!]!
   "Counts per studio (ordered by count descending)"
   studios: [FacetCount!]!
+  "Counts per rating (1-5 stars)"
+  ratings: [RatingFacetCount!]!
 }
 
 """
@@ -155,6 +157,8 @@ type StudioFacetsResult {
   parents: [FacetCount!]!
   "Counts for favorite true/false"
   favorite: [BooleanFacetCount!]!
+  "Counts per rating (1-5 stars)"
+  ratings: [RatingFacetCount!]!
 }
 
 """

--- a/graphql/schema/types/facets.graphql
+++ b/graphql/schema/types/facets.graphql
@@ -97,6 +97,10 @@ type SceneFacetsResult {
   organized: [BooleanFacetCount!]!
   "Counts for interactive true/false"
   interactive: [BooleanFacetCount!]!
+  "Counts for has_markers true/false"
+  has_markers: [BooleanFacetCount!]!
+  "Counts for scenes with at least one favorite performer"
+  performer_favorite: [BooleanFacetCount!]!
   "Counts per rating (1-5 stars)"
   ratings: [RatingFacetCount!]!
   "Counts per caption language"
@@ -145,6 +149,10 @@ type GalleryFacetsResult {
   performer_tags: [FacetCount!]!
   "Counts for organized true/false"
   organized: [BooleanFacetCount!]!
+  "Counts for has_chapters true/false"
+  has_chapters: [BooleanFacetCount!]!
+  "Counts for galleries with at least one favorite performer"
+  performer_favorite: [BooleanFacetCount!]!
   "Counts per rating (1-5 stars)"
   ratings: [RatingFacetCount!]!
 }

--- a/graphql/schema/types/facets.graphql
+++ b/graphql/schema/types/facets.graphql
@@ -103,6 +103,8 @@ type PerformerFacetsResult {
   tags: [FacetCount!]!
   "Counts per studio (ordered by count descending)"
   studios: [FacetCount!]!
+  "Counts per group (via scenes, ordered by count descending)"
+  groups: [FacetCount!]!
   "Counts per gender"
   genders: [GenderFacetCount!]!
   "Counts per country"

--- a/graphql/schema/types/facets.graphql
+++ b/graphql/schema/types/facets.graphql
@@ -67,6 +67,14 @@ type CaptionFacetCount {
 }
 
 """
+A count for a string value (ethnicity, hair color, eye color) within the current filter context
+"""
+type StringFacetCount {
+  value: String!
+  count: Int!
+}
+
+"""
 Facet counts for scene filtering.
 Returns counts for various dimensions to enable efficient faceted search.
 """
@@ -109,6 +117,12 @@ type PerformerFacetsResult {
   genders: [GenderFacetCount!]!
   "Counts per country"
   countries: [FacetCount!]!
+  "Counts per ethnicity"
+  ethnicities: [StringFacetCount!]!
+  "Counts per hair color"
+  hair_colors: [StringFacetCount!]!
+  "Counts per eye color"
+  eye_colors: [StringFacetCount!]!
   "Counts per circumcised value"
   circumcised: [CircumcisedFacetCount!]!
   "Counts for favorite true/false"

--- a/internal/api/resolver_query_facets.go
+++ b/internal/api/resolver_query_facets.go
@@ -201,6 +201,7 @@ func convertPerformerFacets(f *models.PerformerFacets) *PerformerFacetsResult {
 	return &PerformerFacetsResult{
 		Tags:        convertFacetCounts(f.Tags),
 		Studios:     convertFacetCounts(f.Studios),
+		Groups:      convertFacetCounts(f.Groups),
 		Genders:     convertGenderFacetCounts(f.Genders),
 		Countries:   convertFacetCounts(f.Countries),
 		Circumcised: convertCircumcisedFacetCounts(f.Circumcised),

--- a/internal/api/resolver_query_facets.go
+++ b/internal/api/resolver_query_facets.go
@@ -233,6 +233,7 @@ func convertGroupFacets(f *models.GroupFacets) *GroupFacetsResult {
 		Tags:       convertFacetCounts(f.Tags),
 		Performers: convertFacetCounts(f.Performers),
 		Studios:    convertFacetCounts(f.Studios),
+		Ratings:    convertRatingFacetCounts(f.Ratings),
 	}
 }
 
@@ -245,6 +246,7 @@ func convertStudioFacets(f *models.StudioFacets) *StudioFacetsResult {
 		Tags:     convertFacetCounts(f.Tags),
 		Parents:  convertFacetCounts(f.Parents),
 		Favorite: convertBooleanFacetCounts(f.Favorite),
+		Ratings:  convertRatingFacetCounts(f.Ratings),
 	}
 }
 

--- a/internal/api/resolver_query_facets.go
+++ b/internal/api/resolver_query_facets.go
@@ -179,17 +179,19 @@ func convertSceneFacets(f *models.SceneFacets) *SceneFacetsResult {
 	}
 
 	return &SceneFacetsResult{
-		Tags:          convertFacetCounts(f.Tags),
-		Performers:    convertFacetCounts(f.Performers),
-		Studios:       convertFacetCounts(f.Studios),
-		Groups:        convertFacetCounts(f.Groups),
-		PerformerTags: convertFacetCounts(f.PerformerTags),
-		Resolutions:   convertResolutionFacetCounts(f.Resolutions),
-		Orientations:  convertOrientationFacetCounts(f.Orientations),
-		Organized:     convertBooleanFacetCounts(f.Organized),
-		Interactive:   convertBooleanFacetCounts(f.Interactive),
-		Ratings:       convertRatingFacetCounts(f.Ratings),
-		Captions:      convertCaptionFacetCounts(f.Captions),
+		Tags:              convertFacetCounts(f.Tags),
+		Performers:        convertFacetCounts(f.Performers),
+		Studios:           convertFacetCounts(f.Studios),
+		Groups:            convertFacetCounts(f.Groups),
+		PerformerTags:     convertFacetCounts(f.PerformerTags),
+		Resolutions:       convertResolutionFacetCounts(f.Resolutions),
+		Orientations:      convertOrientationFacetCounts(f.Orientations),
+		Organized:         convertBooleanFacetCounts(f.Organized),
+		Interactive:       convertBooleanFacetCounts(f.Interactive),
+		HasMarkers:        convertBooleanFacetCounts(f.HasMarkers),
+		PerformerFavorite: convertBooleanFacetCounts(f.PerformerFavorite),
+		Ratings:           convertRatingFacetCounts(f.Ratings),
+		Captions:          convertCaptionFacetCounts(f.Captions),
 	}
 }
 
@@ -219,12 +221,14 @@ func convertGalleryFacets(f *models.GalleryFacets) *GalleryFacetsResult {
 	}
 
 	return &GalleryFacetsResult{
-		Tags:          convertFacetCounts(f.Tags),
-		Performers:    convertFacetCounts(f.Performers),
-		Studios:       convertFacetCounts(f.Studios),
-		PerformerTags: convertFacetCounts(f.PerformerTags),
-		Organized:     convertBooleanFacetCounts(f.Organized),
-		Ratings:       convertRatingFacetCounts(f.Ratings),
+		Tags:              convertFacetCounts(f.Tags),
+		Performers:        convertFacetCounts(f.Performers),
+		Studios:           convertFacetCounts(f.Studios),
+		PerformerTags:     convertFacetCounts(f.PerformerTags),
+		Organized:         convertBooleanFacetCounts(f.Organized),
+		HasChapters:       convertBooleanFacetCounts(f.HasChapters),
+		PerformerFavorite: convertBooleanFacetCounts(f.PerformerFavorite),
+		Ratings:           convertRatingFacetCounts(f.Ratings),
 	}
 }
 

--- a/internal/api/resolver_query_facets.go
+++ b/internal/api/resolver_query_facets.go
@@ -204,6 +204,9 @@ func convertPerformerFacets(f *models.PerformerFacets) *PerformerFacetsResult {
 		Groups:      convertFacetCounts(f.Groups),
 		Genders:     convertGenderFacetCounts(f.Genders),
 		Countries:   convertFacetCounts(f.Countries),
+		Ethnicities: convertStringFacetCounts(f.Ethnicities),
+		HairColors:  convertStringFacetCounts(f.HairColors),
+		EyeColors:   convertStringFacetCounts(f.EyeColors),
 		Circumcised: convertCircumcisedFacetCounts(f.Circumcised),
 		Favorite:    convertBooleanFacetCounts(f.Favorite),
 		Ratings:     convertRatingFacetCounts(f.Ratings),
@@ -334,6 +337,17 @@ func convertCircumcisedFacetCounts(counts []models.CircumcisedFacetCount) []*Cir
 	result := make([]*CircumcisedFacetCount, len(counts))
 	for i, c := range counts {
 		result[i] = &CircumcisedFacetCount{
+			Value: c.Value,
+			Count: c.Count,
+		}
+	}
+	return result
+}
+
+func convertStringFacetCounts(counts []models.StringFacetCount) []*StringFacetCount {
+	result := make([]*StringFacetCount, len(counts))
+	for i, c := range counts {
+		result[i] = &StringFacetCount{
 			Value: c.Value,
 			Count: c.Count,
 		}

--- a/internal/api/types_facets.go
+++ b/internal/api/types_facets.go
@@ -59,17 +59,19 @@ type StringFacetCount struct {
 
 // SceneFacetsResult contains all facet counts for scene filtering
 type SceneFacetsResult struct {
-	Tags          []*FacetCount            `json:"tags"`
-	Performers    []*FacetCount            `json:"performers"`
-	Studios       []*FacetCount            `json:"studios"`
-	Groups        []*FacetCount            `json:"groups"`
-	PerformerTags []*FacetCount            `json:"performer_tags"`
-	Resolutions   []*ResolutionFacetCount  `json:"resolutions"`
-	Orientations  []*OrientationFacetCount `json:"orientations"`
-	Organized     []*BooleanFacetCount     `json:"organized"`
-	Interactive   []*BooleanFacetCount     `json:"interactive"`
-	Ratings       []*RatingFacetCount      `json:"ratings"`
-	Captions      []*CaptionFacetCount     `json:"captions"`
+	Tags              []*FacetCount            `json:"tags"`
+	Performers        []*FacetCount            `json:"performers"`
+	Studios           []*FacetCount            `json:"studios"`
+	Groups            []*FacetCount            `json:"groups"`
+	PerformerTags     []*FacetCount            `json:"performer_tags"`
+	Resolutions       []*ResolutionFacetCount  `json:"resolutions"`
+	Orientations      []*OrientationFacetCount `json:"orientations"`
+	Organized         []*BooleanFacetCount     `json:"organized"`
+	Interactive       []*BooleanFacetCount     `json:"interactive"`
+	HasMarkers        []*BooleanFacetCount     `json:"has_markers"`
+	PerformerFavorite []*BooleanFacetCount     `json:"performer_favorite"`
+	Ratings           []*RatingFacetCount      `json:"ratings"`
+	Captions          []*CaptionFacetCount     `json:"captions"`
 }
 
 // PerformerFacetsResult contains all facet counts for performer filtering
@@ -89,12 +91,14 @@ type PerformerFacetsResult struct {
 
 // GalleryFacetsResult contains all facet counts for gallery filtering
 type GalleryFacetsResult struct {
-	Tags          []*FacetCount        `json:"tags"`
-	Performers    []*FacetCount        `json:"performers"`
-	Studios       []*FacetCount        `json:"studios"`
-	PerformerTags []*FacetCount        `json:"performer_tags"`
-	Organized     []*BooleanFacetCount `json:"organized"`
-	Ratings       []*RatingFacetCount  `json:"ratings"`
+	Tags              []*FacetCount        `json:"tags"`
+	Performers        []*FacetCount        `json:"performers"`
+	Studios           []*FacetCount        `json:"studios"`
+	PerformerTags     []*FacetCount        `json:"performer_tags"`
+	Organized         []*BooleanFacetCount `json:"organized"`
+	HasChapters       []*BooleanFacetCount `json:"has_chapters"`
+	PerformerFavorite []*BooleanFacetCount `json:"performer_favorite"`
+	Ratings           []*RatingFacetCount  `json:"ratings"`
 }
 
 // GroupFacetsResult contains all facet counts for group filtering

--- a/internal/api/types_facets.go
+++ b/internal/api/types_facets.go
@@ -70,6 +70,7 @@ type SceneFacetsResult struct {
 type PerformerFacetsResult struct {
 	Tags        []*FacetCount            `json:"tags"`
 	Studios     []*FacetCount            `json:"studios"`
+	Groups      []*FacetCount            `json:"groups"`
 	Genders     []*GenderFacetCount      `json:"genders"`
 	Countries   []*FacetCount            `json:"countries"`
 	Circumcised []*CircumcisedFacetCount `json:"circumcised"`

--- a/internal/api/types_facets.go
+++ b/internal/api/types_facets.go
@@ -51,6 +51,12 @@ type CaptionFacetCount struct {
 	Count    int    `json:"count"`
 }
 
+// StringFacetCount represents a count for a string value (ethnicity, hair color, etc.)
+type StringFacetCount struct {
+	Value string `json:"value"`
+	Count int    `json:"count"`
+}
+
 // SceneFacetsResult contains all facet counts for scene filtering
 type SceneFacetsResult struct {
 	Tags          []*FacetCount            `json:"tags"`
@@ -73,6 +79,9 @@ type PerformerFacetsResult struct {
 	Groups      []*FacetCount            `json:"groups"`
 	Genders     []*GenderFacetCount      `json:"genders"`
 	Countries   []*FacetCount            `json:"countries"`
+	Ethnicities []*StringFacetCount      `json:"ethnicities"`
+	HairColors  []*StringFacetCount      `json:"hair_colors"`
+	EyeColors   []*StringFacetCount      `json:"eye_colors"`
 	Circumcised []*CircumcisedFacetCount `json:"circumcised"`
 	Favorite    []*BooleanFacetCount     `json:"favorite"`
 	Ratings     []*RatingFacetCount      `json:"ratings"`

--- a/pkg/models/facets.go
+++ b/pkg/models/facets.go
@@ -58,17 +58,19 @@ type StringFacetCount struct {
 // SceneFacets contains all facet counts for scene filtering
 // All facets are always computed (no lazy loading) - they run in parallel goroutines
 type SceneFacets struct {
-	Tags          []FacetCount
-	Performers    []FacetCount
-	Studios       []FacetCount
-	Groups        []FacetCount
-	PerformerTags []FacetCount
-	Resolutions   []ResolutionFacetCount
-	Orientations  []OrientationFacetCount
-	Organized     []BooleanFacetCount
-	Interactive   []BooleanFacetCount
-	Ratings       []RatingFacetCount
-	Captions      []CaptionFacetCount
+	Tags            []FacetCount
+	Performers      []FacetCount
+	Studios         []FacetCount
+	Groups          []FacetCount
+	PerformerTags   []FacetCount
+	Resolutions     []ResolutionFacetCount
+	Orientations    []OrientationFacetCount
+	Organized       []BooleanFacetCount
+	Interactive     []BooleanFacetCount
+	HasMarkers      []BooleanFacetCount
+	PerformerFavorite []BooleanFacetCount
+	Ratings         []RatingFacetCount
+	Captions        []CaptionFacetCount
 }
 
 // PerformerFacets contains all facet counts for performer filtering
@@ -89,12 +91,14 @@ type PerformerFacets struct {
 // GalleryFacets contains all facet counts for gallery filtering
 // All facets are always computed (no lazy loading) - they run in parallel goroutines
 type GalleryFacets struct {
-	Tags          []FacetCount
-	Performers    []FacetCount
-	Studios       []FacetCount
-	PerformerTags []FacetCount
-	Organized     []BooleanFacetCount
-	Ratings       []RatingFacetCount
+	Tags              []FacetCount
+	Performers        []FacetCount
+	Studios           []FacetCount
+	PerformerTags     []FacetCount
+	Organized         []BooleanFacetCount
+	HasChapters       []BooleanFacetCount
+	PerformerFavorite []BooleanFacetCount
+	Ratings           []RatingFacetCount
 }
 
 // GroupFacets contains all facet counts for group filtering

--- a/pkg/models/facets.go
+++ b/pkg/models/facets.go
@@ -49,6 +49,12 @@ type CaptionFacetCount struct {
 	Count    int
 }
 
+// StringFacetCount represents a count for a string value (ethnicity, hair color, etc.)
+type StringFacetCount struct {
+	Value string
+	Count int
+}
+
 // SceneFacets contains all facet counts for scene filtering
 // All facets are always computed (no lazy loading) - they run in parallel goroutines
 type SceneFacets struct {
@@ -72,6 +78,9 @@ type PerformerFacets struct {
 	Groups      []FacetCount
 	Genders     []GenderFacetCount
 	Countries   []FacetCount
+	Ethnicities []StringFacetCount
+	HairColors  []StringFacetCount
+	EyeColors   []StringFacetCount
 	Circumcised []CircumcisedFacetCount
 	Favorite    []BooleanFacetCount
 	Ratings     []RatingFacetCount

--- a/pkg/models/facets.go
+++ b/pkg/models/facets.go
@@ -92,6 +92,7 @@ type GroupFacets struct {
 	Tags       []FacetCount
 	Performers []FacetCount
 	Studios    []FacetCount
+	Ratings    []RatingFacetCount
 }
 
 // StudioFacets contains all facet counts for studio filtering
@@ -99,6 +100,7 @@ type StudioFacets struct {
 	Tags     []FacetCount
 	Parents  []FacetCount
 	Favorite []BooleanFacetCount
+	Ratings  []RatingFacetCount
 }
 
 // TagFacets contains all facet counts for tag filtering

--- a/pkg/models/facets.go
+++ b/pkg/models/facets.go
@@ -69,6 +69,7 @@ type SceneFacets struct {
 type PerformerFacets struct {
 	Tags        []FacetCount
 	Studios     []FacetCount
+	Groups      []FacetCount
 	Genders     []GenderFacetCount
 	Countries   []FacetCount
 	Circumcised []CircumcisedFacetCount

--- a/pkg/sqlite/gallery_facets.go
+++ b/pkg/sqlite/gallery_facets.go
@@ -52,12 +52,14 @@ func isEmptyGalleryFilter(filter *models.GalleryFilterType) bool {
 // When no filter is applied, uses optimized "fast path" queries that skip the CTE.
 func (qb *GalleryStore) GetFacets(ctx context.Context, galleryFilter *models.GalleryFilterType, limit int) (*models.GalleryFacets, error) {
 	result := &models.GalleryFacets{
-		Tags:          []models.FacetCount{},
-		Performers:    []models.FacetCount{},
-		Studios:       []models.FacetCount{},
-		PerformerTags: []models.FacetCount{},
-		Organized:     []models.BooleanFacetCount{},
-		Ratings:       []models.RatingFacetCount{},
+		Tags:              []models.FacetCount{},
+		Performers:        []models.FacetCount{},
+		Studios:           []models.FacetCount{},
+		PerformerTags:     []models.FacetCount{},
+		Organized:         []models.BooleanFacetCount{},
+		HasChapters:       []models.BooleanFacetCount{},
+		PerformerFavorite: []models.BooleanFacetCount{},
+		Ratings:           []models.RatingFacetCount{},
 	}
 
 	// Fast path: When no filter is applied, use optimized direct queries
@@ -76,7 +78,7 @@ func (qb *GalleryStore) GetFacets(ctx context.Context, galleryFilter *models.Gal
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 6) // 6 parallel goroutines
+	errChan := make(chan error, 7) // 7 parallel goroutines
 
 	// All facets run in parallel - no lazy loading
 	// Wall-clock time = slowest query, not sum of queries
@@ -126,6 +128,15 @@ func (qb *GalleryStore) GetFacets(ctx context.Context, galleryFilter *models.Gal
 		}
 	}()
 
+	// Advanced boolean facets (has_chapters, performer_favorite)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := qb.getAdvancedBooleanFacets(ctx, baseSQL, baseArgs, result, &mu); err != nil {
+			errChan <- fmt.Errorf("advanced boolean facets: %w", err)
+		}
+	}()
+
 	wg.Wait()
 	close(errChan)
 
@@ -147,7 +158,7 @@ func (qb *GalleryStore) GetFacets(ctx context.Context, galleryFilter *models.Gal
 func (qb *GalleryStore) getFacetsUnfiltered(ctx context.Context, limit int, result *models.GalleryFacets) (*models.GalleryFacets, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 6)
+	errChan := make(chan error, 7)
 
 	// Tags - direct count on galleries_tags
 	wg.Add(1)
@@ -342,6 +353,77 @@ func (qb *GalleryStore) getFacetsUnfiltered(ctx context.Context, limit int, resu
 		mu.Lock()
 		result.Organized = organized
 		result.Ratings = ratings
+		mu.Unlock()
+	}()
+
+	// Advanced boolean facets (has_chapters, performer_favorite) - unfiltered
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// HasChapters - count galleries with at least one chapter
+		hasChaptersRows, err := dbWrapper.Queryx(ctx, `
+			SELECT 
+				CASE WHEN chapter_count > 0 THEN 'true' ELSE 'false' END as has_chapters,
+				COUNT(*) as count
+			FROM (
+				SELECT g.id, COUNT(gc.id) as chapter_count
+				FROM galleries g
+				LEFT JOIN galleries_chapters gc ON g.id = gc.gallery_id
+				GROUP BY g.id
+			)
+			GROUP BY has_chapters
+		`)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered has_chapters facet: %w", err)
+			return
+		}
+		defer hasChaptersRows.Close()
+
+		var hasChapters []models.BooleanFacetCount
+		for hasChaptersRows.Next() {
+			var value string
+			var count int
+			if err := hasChaptersRows.Scan(&value, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered has_chapters: %w", err)
+				return
+			}
+			hasChapters = append(hasChapters, models.BooleanFacetCount{Value: value == "true", Count: count})
+		}
+
+		// PerformerFavorite - count galleries with at least one favorite performer
+		perfFavRows, err := dbWrapper.Queryx(ctx, `
+			SELECT 
+				CASE WHEN fav_count > 0 THEN 'true' ELSE 'false' END as has_favorite,
+				COUNT(*) as count
+			FROM (
+				SELECT g.id, SUM(CASE WHEN p.favorite = 1 THEN 1 ELSE 0 END) as fav_count
+				FROM galleries g
+				LEFT JOIN performers_galleries pg ON g.id = pg.gallery_id
+				LEFT JOIN performers p ON pg.performer_id = p.id
+				GROUP BY g.id
+			)
+			GROUP BY has_favorite
+		`)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered performer_favorite facet: %w", err)
+			return
+		}
+		defer perfFavRows.Close()
+
+		var performerFavorite []models.BooleanFacetCount
+		for perfFavRows.Next() {
+			var value string
+			var count int
+			if err := perfFavRows.Scan(&value, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered performer_favorite: %w", err)
+				return
+			}
+			performerFavorite = append(performerFavorite, models.BooleanFacetCount{Value: value == "true", Count: count})
+		}
+
+		mu.Lock()
+		result.HasChapters = hasChapters
+		result.PerformerFavorite = performerFavorite
 		mu.Unlock()
 	}()
 
@@ -570,5 +652,80 @@ func (qb *GalleryStore) getSimpleFacets(ctx context.Context, baseSQL string, bas
 	result.Organized = organized
 	result.Ratings = ratings
 	mu.Unlock()
+	return nil
+}
+
+// getAdvancedBooleanFacets fetches has_chapters and performer_favorite facets
+func (qb *GalleryStore) getAdvancedBooleanFacets(ctx context.Context, baseSQL string, baseArgs []interface{}, result *models.GalleryFacets, mu *sync.Mutex) error {
+	args := append([]interface{}{}, baseArgs...)
+
+	// HasChapters - count galleries with at least one chapter
+	hasChaptersSQL := fmt.Sprintf(`
+		WITH filtered_galleries AS (%s)
+		SELECT 
+			CASE WHEN chapter_count > 0 THEN 'true' ELSE 'false' END as has_chapters,
+			COUNT(*) as count
+		FROM (
+			SELECT fg.id, COUNT(gc.id) as chapter_count
+			FROM filtered_galleries fg
+			LEFT JOIN galleries_chapters gc ON fg.id = gc.gallery_id
+			GROUP BY fg.id
+		)
+		GROUP BY has_chapters
+	`, baseSQL)
+
+	hasChaptersRows, err := dbWrapper.Queryx(ctx, hasChaptersSQL, args...)
+	if err != nil {
+		return fmt.Errorf("error executing has_chapters facet query: %w", err)
+	}
+	defer hasChaptersRows.Close()
+
+	var hasChapters []models.BooleanFacetCount
+	for hasChaptersRows.Next() {
+		var value string
+		var count int
+		if err := hasChaptersRows.Scan(&value, &count); err != nil {
+			return fmt.Errorf("error scanning has_chapters row: %w", err)
+		}
+		hasChapters = append(hasChapters, models.BooleanFacetCount{Value: value == "true", Count: count})
+	}
+
+	// PerformerFavorite - count galleries with at least one favorite performer
+	perfFavSQL := fmt.Sprintf(`
+		WITH filtered_galleries AS (%s)
+		SELECT 
+			CASE WHEN fav_count > 0 THEN 'true' ELSE 'false' END as has_favorite,
+			COUNT(*) as count
+		FROM (
+			SELECT fg.id, SUM(CASE WHEN p.favorite = 1 THEN 1 ELSE 0 END) as fav_count
+			FROM filtered_galleries fg
+			LEFT JOIN performers_galleries pg ON fg.id = pg.gallery_id
+			LEFT JOIN performers p ON pg.performer_id = p.id
+			GROUP BY fg.id
+		)
+		GROUP BY has_favorite
+	`, baseSQL)
+
+	perfFavRows, err := dbWrapper.Queryx(ctx, perfFavSQL, args...)
+	if err != nil {
+		return fmt.Errorf("error executing performer_favorite facet query: %w", err)
+	}
+	defer perfFavRows.Close()
+
+	var performerFavorite []models.BooleanFacetCount
+	for perfFavRows.Next() {
+		var value string
+		var count int
+		if err := perfFavRows.Scan(&value, &count); err != nil {
+			return fmt.Errorf("error scanning performer_favorite row: %w", err)
+		}
+		performerFavorite = append(performerFavorite, models.BooleanFacetCount{Value: value == "true", Count: count})
+	}
+
+	mu.Lock()
+	result.HasChapters = hasChapters
+	result.PerformerFavorite = performerFavorite
+	mu.Unlock()
+
 	return nil
 }

--- a/pkg/sqlite/gallery_facets_test.go
+++ b/pkg/sqlite/gallery_facets_test.go
@@ -240,7 +240,53 @@ func TestGalleryFacets_ReturnsAllFacetsInParallel(t *testing.T) {
 		assert.NotNil(t, facets.Studios, "Studios should not be nil")
 		assert.NotNil(t, facets.PerformerTags, "PerformerTags should not be nil")
 		assert.NotNil(t, facets.Organized, "Organized should not be nil")
+		assert.NotNil(t, facets.HasChapters, "HasChapters should not be nil")
+		assert.NotNil(t, facets.PerformerFavorite, "PerformerFavorite should not be nil")
 		assert.NotNil(t, facets.Ratings, "Ratings should not be nil")
+
+		return nil
+	})
+}
+
+// Phase 7.4: Test has_chapters facet
+func TestGalleryFacets_ReturnsHasChapters(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		gqb := db.Gallery
+
+		facets, err := gqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// HasChapters should be returned (may have true and false counts)
+		assert.NotNil(t, facets.HasChapters, "HasChapters should not be nil")
+
+		for _, hc := range facets.HasChapters {
+			assert.GreaterOrEqual(t, hc.Count, 0, "HasChapters count should be non-negative")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.4: Test performer_favorite facet for galleries
+func TestGalleryFacets_ReturnsPerformerFavorite(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		gqb := db.Gallery
+
+		facets, err := gqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// PerformerFavorite should be returned (may have true and false counts)
+		assert.NotNil(t, facets.PerformerFavorite, "PerformerFavorite should not be nil")
+
+		for _, pf := range facets.PerformerFavorite {
+			assert.GreaterOrEqual(t, pf.Count, 0, "PerformerFavorite count should be non-negative")
+		}
 
 		return nil
 	})

--- a/pkg/sqlite/group_facets.go
+++ b/pkg/sqlite/group_facets.go
@@ -48,6 +48,7 @@ func (qb *GroupStore) GetFacets(ctx context.Context, groupFilter *models.GroupFi
 		Tags:       []models.FacetCount{},
 		Performers: []models.FacetCount{},
 		Studios:    []models.FacetCount{},
+		Ratings:    []models.RatingFacetCount{},
 	}
 
 	// Fast path: When no filter is applied, use optimized direct queries
@@ -66,7 +67,7 @@ func (qb *GroupStore) GetFacets(ctx context.Context, groupFilter *models.GroupFi
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 3) // 3 parallel goroutines
+	errChan := make(chan error, 4) // 4 parallel goroutines
 
 	// All facets run in parallel - no lazy loading
 	// Wall-clock time = slowest query, not sum of queries
@@ -98,6 +99,15 @@ func (qb *GroupStore) GetFacets(ctx context.Context, groupFilter *models.GroupFi
 		}
 	}()
 
+	// Ratings facet
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := qb.getRatingsFacet(ctx, baseSQL, baseArgs, result, &mu); err != nil {
+			errChan <- fmt.Errorf("ratings facet: %w", err)
+		}
+	}()
+
 	wg.Wait()
 	close(errChan)
 
@@ -115,7 +125,7 @@ func (qb *GroupStore) GetFacets(ctx context.Context, groupFilter *models.GroupFi
 func (qb *GroupStore) getFacetsUnfiltered(ctx context.Context, limit int, result *models.GroupFacets) (*models.GroupFacets, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 3)
+	errChan := make(chan error, 4)
 
 	// Tags - direct count on groups_tags
 	wg.Add(1)
@@ -218,6 +228,38 @@ func (qb *GroupStore) getFacetsUnfiltered(ctx context.Context, limit int, result
 		}
 		mu.Lock()
 		result.Studios = studios
+		mu.Unlock()
+	}()
+
+	// Ratings - direct count on groups
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rows, err := dbWrapper.Queryx(ctx, `
+			SELECT rating, COUNT(*) as count
+			FROM groups
+			WHERE rating IS NOT NULL
+			GROUP BY rating
+			ORDER BY rating DESC
+		`)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered ratings facet: %w", err)
+			return
+		}
+		defer rows.Close()
+
+		var ratings []models.RatingFacetCount
+		for rows.Next() {
+			var rating int
+			var count int
+			if err := rows.Scan(&rating, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered rating: %w", err)
+				return
+			}
+			ratings = append(ratings, models.RatingFacetCount{Rating: rating, Count: count})
+		}
+		mu.Lock()
+		result.Ratings = ratings
 		mu.Unlock()
 	}()
 
@@ -342,6 +384,39 @@ func (qb *GroupStore) getStudiosFacet(ctx context.Context, baseSQL string, baseA
 
 	mu.Lock()
 	result.Studios = studios
+	mu.Unlock()
+	return rows.Err()
+}
+
+func (qb *GroupStore) getRatingsFacet(ctx context.Context, baseSQL string, baseArgs []interface{}, result *models.GroupFacets, mu *sync.Mutex) error {
+	sql := fmt.Sprintf(`
+		WITH filtered_groups AS (%s)
+		SELECT g.rating, COUNT(*) as count
+		FROM filtered_groups fg
+		INNER JOIN groups g ON fg.id = g.id
+		WHERE g.rating IS NOT NULL
+		GROUP BY g.rating
+		ORDER BY g.rating DESC
+	`, baseSQL)
+
+	rows, err := dbWrapper.Queryx(ctx, sql, baseArgs...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var ratings []models.RatingFacetCount
+	for rows.Next() {
+		var rating int
+		var count int
+		if err := rows.Scan(&rating, &count); err != nil {
+			return err
+		}
+		ratings = append(ratings, models.RatingFacetCount{Rating: rating, Count: count})
+	}
+
+	mu.Lock()
+	result.Ratings = ratings
 	mu.Unlock()
 	return rows.Err()
 }

--- a/pkg/sqlite/group_facets_test.go
+++ b/pkg/sqlite/group_facets_test.go
@@ -201,3 +201,60 @@ func TestGroupFacets_UnfilteredFastPath(t *testing.T) {
 		return nil
 	})
 }
+
+// Phase 7.2: Test ratings facet
+func TestGroupFacets_ReturnsRatings(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		mqb := db.Group
+
+		facets, err := mqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Ratings should not be nil
+		assert.NotNil(t, facets.Ratings, "Ratings should not be nil")
+
+		// All rating counts should be positive
+		for _, r := range facets.Ratings {
+			assert.Greater(t, r.Count, 0, "Rating count should be positive")
+			assert.Greater(t, r.Rating, 0, "Rating value should be positive")
+			assert.LessOrEqual(t, r.Rating, 100, "Rating value should be <= 100")
+		}
+
+		// Verify ratings are sorted by rating descending
+		for i := 1; i < len(facets.Ratings); i++ {
+			assert.GreaterOrEqual(t, facets.Ratings[i-1].Rating, facets.Ratings[i].Rating,
+				"Ratings should be sorted by rating descending")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.2: Test ratings with filter
+func TestGroupFacets_RatingsWithFilter(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		mqb := db.Group
+
+		// Filter to groups with specific studio
+		studioFilter := &models.GroupFilterType{
+			Studios: &models.HierarchicalMultiCriterionInput{
+				Value:    []string{strconv.Itoa(studioIDs[studioIdxWithGroup])},
+				Modifier: models.CriterionModifierIncludes,
+			},
+		}
+
+		facets, err := mqb.GetFacets(ctx, studioFilter, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Ratings should not be nil even with filter
+		assert.NotNil(t, facets.Ratings, "Ratings should not be nil with filter")
+
+		return nil
+	})
+}

--- a/pkg/sqlite/performer_facets.go
+++ b/pkg/sqlite/performer_facets.go
@@ -75,6 +75,7 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 	result := &models.PerformerFacets{
 		Tags:        []models.FacetCount{},
 		Studios:     []models.FacetCount{},
+		Groups:      []models.FacetCount{},
 		Genders:     []models.GenderFacetCount{},
 		Countries:   []models.FacetCount{},
 		Circumcised: []models.CircumcisedFacetCount{},
@@ -98,7 +99,7 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 5) // 5 parallel goroutines
+	errChan := make(chan error, 6) // 6 parallel goroutines
 
 	// All facets run in parallel - no lazy loading
 	// Wall-clock time = slowest query, not sum of queries
@@ -118,6 +119,15 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 		defer wg.Done()
 		if err := qb.getStudiosFacet(ctx, baseSQL, baseArgs, limit, result, &mu); err != nil {
 			errChan <- fmt.Errorf("studios facet: %w", err)
+		}
+	}()
+
+	// Groups facet (via performers_scenes -> groups_scenes -> groups)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := qb.getGroupsFacet(ctx, baseSQL, baseArgs, limit, result, &mu); err != nil {
+			errChan <- fmt.Errorf("groups facet: %w", err)
 		}
 	}()
 
@@ -156,7 +166,7 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 func (qb *PerformerStore) getFacetsUnfiltered(ctx context.Context, limit int, result *models.PerformerFacets) (*models.PerformerFacets, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 5)
+	errChan := make(chan error, 6)
 
 	// Tags - direct count on performers_tags
 	wg.Add(1)
@@ -225,6 +235,41 @@ func (qb *PerformerStore) getFacetsUnfiltered(ctx context.Context, limit int, re
 		}
 		mu.Lock()
 		result.Studios = studios
+		mu.Unlock()
+	}()
+
+	// Groups - via performers_scenes -> groups_scenes -> groups
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rows, err := dbWrapper.Queryx(ctx, `
+			SELECT g.id, g.name as label, COUNT(DISTINCT ps.performer_id) as count
+			FROM performers_scenes ps
+			INNER JOIN groups_scenes gs ON ps.scene_id = gs.scene_id
+			INNER JOIN groups g ON gs.group_id = g.id
+			GROUP BY g.id
+			ORDER BY count DESC
+			LIMIT ?
+		`, limit)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered groups facet: %w", err)
+			return
+		}
+		defer rows.Close()
+
+		var groups []models.FacetCount
+		for rows.Next() {
+			var id int
+			var label string
+			var count int
+			if err := rows.Scan(&id, &label, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered group: %w", err)
+				return
+			}
+			groups = append(groups, models.FacetCount{ID: strconv.Itoa(id), Label: label, Count: count})
+		}
+		mu.Lock()
+		result.Groups = groups
 		mu.Unlock()
 	}()
 
@@ -462,6 +507,43 @@ func (qb *PerformerStore) getStudiosFacet(ctx context.Context, baseSQL string, b
 
 	mu.Lock()
 	result.Studios = studios
+	mu.Unlock()
+	return rows.Err()
+}
+
+func (qb *PerformerStore) getGroupsFacet(ctx context.Context, baseSQL string, baseArgs []interface{}, limit int, result *models.PerformerFacets, mu *sync.Mutex) error {
+	sql := fmt.Sprintf(`
+		WITH filtered_performers AS (%s)
+		SELECT g.id, g.name as label, COUNT(DISTINCT ps.performer_id) as count
+		FROM filtered_performers fp
+		INNER JOIN performers_scenes ps ON fp.id = ps.performer_id
+		INNER JOIN groups_scenes gs ON ps.scene_id = gs.scene_id
+		INNER JOIN groups g ON gs.group_id = g.id
+		GROUP BY g.id
+		ORDER BY count DESC
+		LIMIT ?
+	`, baseSQL)
+
+	args := append(append([]interface{}{}, baseArgs...), limit)
+	rows, err := dbWrapper.Queryx(ctx, sql, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var groups []models.FacetCount
+	for rows.Next() {
+		var id int
+		var label string
+		var count int
+		if err := rows.Scan(&id, &label, &count); err != nil {
+			return err
+		}
+		groups = append(groups, models.FacetCount{ID: strconv.Itoa(id), Label: label, Count: count})
+	}
+
+	mu.Lock()
+	result.Groups = groups
 	mu.Unlock()
 	return rows.Err()
 }

--- a/pkg/sqlite/performer_facets.go
+++ b/pkg/sqlite/performer_facets.go
@@ -78,6 +78,9 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 		Groups:      []models.FacetCount{},
 		Genders:     []models.GenderFacetCount{},
 		Countries:   []models.FacetCount{},
+		Ethnicities: []models.StringFacetCount{},
+		HairColors:  []models.StringFacetCount{},
+		EyeColors:   []models.StringFacetCount{},
 		Circumcised: []models.CircumcisedFacetCount{},
 		Favorite:    []models.BooleanFacetCount{},
 		Ratings:     []models.RatingFacetCount{},
@@ -99,7 +102,7 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 6) // 6 parallel goroutines
+	errChan := make(chan error, 7) // 7 parallel goroutines
 
 	// All facets run in parallel - no lazy loading
 	// Wall-clock time = slowest query, not sum of queries
@@ -149,6 +152,15 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 		}
 	}()
 
+	// Attribute facets (ethnicity, hair_color, eye_color)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := qb.getAttributeFacets(ctx, baseSQL, baseArgs, limit, result, &mu); err != nil {
+			errChan <- fmt.Errorf("attribute facets: %w", err)
+		}
+	}()
+
 	wg.Wait()
 	close(errChan)
 
@@ -166,7 +178,7 @@ func (qb *PerformerStore) GetFacets(ctx context.Context, performerFilter *models
 func (qb *PerformerStore) getFacetsUnfiltered(ctx context.Context, limit int, result *models.PerformerFacets) (*models.PerformerFacets, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 6)
+	errChan := make(chan error, 7)
 
 	// Tags - direct count on performers_tags
 	wg.Add(1)
@@ -419,6 +431,95 @@ func (qb *PerformerStore) getFacetsUnfiltered(ctx context.Context, limit int, re
 		result.Favorite = favorite
 		result.Circumcised = circumcised
 		result.Ratings = ratings
+		mu.Unlock()
+	}()
+
+	// Attribute facets (ethnicity, hair_color, eye_color)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Ethnicity
+		ethnicityRows, err := dbWrapper.Queryx(ctx, `
+			SELECT ethnicity as value, COUNT(*) as count
+			FROM performers
+			WHERE ethnicity IS NOT NULL AND ethnicity != ''
+			GROUP BY ethnicity
+			ORDER BY count DESC
+			LIMIT ?
+		`, limit)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered ethnicity facet: %w", err)
+			return
+		}
+		defer ethnicityRows.Close()
+
+		var ethnicities []models.StringFacetCount
+		for ethnicityRows.Next() {
+			var value string
+			var count int
+			if err := ethnicityRows.Scan(&value, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered ethnicity: %w", err)
+				return
+			}
+			ethnicities = append(ethnicities, models.StringFacetCount{Value: value, Count: count})
+		}
+
+		// Hair Color
+		hairRows, err := dbWrapper.Queryx(ctx, `
+			SELECT hair_color as value, COUNT(*) as count
+			FROM performers
+			WHERE hair_color IS NOT NULL AND hair_color != ''
+			GROUP BY hair_color
+			ORDER BY count DESC
+			LIMIT ?
+		`, limit)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered hair_color facet: %w", err)
+			return
+		}
+		defer hairRows.Close()
+
+		var hairColors []models.StringFacetCount
+		for hairRows.Next() {
+			var value string
+			var count int
+			if err := hairRows.Scan(&value, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered hair_color: %w", err)
+				return
+			}
+			hairColors = append(hairColors, models.StringFacetCount{Value: value, Count: count})
+		}
+
+		// Eye Color
+		eyeRows, err := dbWrapper.Queryx(ctx, `
+			SELECT eye_color as value, COUNT(*) as count
+			FROM performers
+			WHERE eye_color IS NOT NULL AND eye_color != ''
+			GROUP BY eye_color
+			ORDER BY count DESC
+			LIMIT ?
+		`, limit)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered eye_color facet: %w", err)
+			return
+		}
+		defer eyeRows.Close()
+
+		var eyeColors []models.StringFacetCount
+		for eyeRows.Next() {
+			var value string
+			var count int
+			if err := eyeRows.Scan(&value, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered eye_color: %w", err)
+				return
+			}
+			eyeColors = append(eyeColors, models.StringFacetCount{Value: value, Count: count})
+		}
+
+		mu.Lock()
+		result.Ethnicities = ethnicities
+		result.HairColors = hairColors
+		result.EyeColors = eyeColors
 		mu.Unlock()
 	}()
 
@@ -712,6 +813,106 @@ func (qb *PerformerStore) getSimpleFacets(ctx context.Context, baseSQL string, b
 	result.Favorite = favorite
 	result.Circumcised = circumcised
 	result.Ratings = ratings
+	mu.Unlock()
+	return nil
+}
+
+func (qb *PerformerStore) getAttributeFacets(ctx context.Context, baseSQL string, baseArgs []interface{}, limit int, result *models.PerformerFacets, mu *sync.Mutex) error {
+	// Ethnicity facet
+	ethnicitySQL := fmt.Sprintf(`
+		WITH filtered_performers AS (%s)
+		SELECT p.ethnicity as value, COUNT(*) as count
+		FROM filtered_performers fp
+		INNER JOIN performers p ON fp.id = p.id
+		WHERE p.ethnicity IS NOT NULL AND p.ethnicity != ''
+		GROUP BY p.ethnicity
+		ORDER BY count DESC
+		LIMIT ?
+	`, baseSQL)
+
+	args := append(append([]interface{}{}, baseArgs...), limit)
+	ethnicityRows, err := dbWrapper.Queryx(ctx, ethnicitySQL, args...)
+	if err != nil {
+		return fmt.Errorf("ethnicity facet: %w", err)
+	}
+	defer ethnicityRows.Close()
+
+	var ethnicities []models.StringFacetCount
+	for ethnicityRows.Next() {
+		var value stdsql.NullString
+		var count int
+		if err := ethnicityRows.Scan(&value, &count); err != nil {
+			return fmt.Errorf("scanning ethnicity: %w", err)
+		}
+		if value.Valid {
+			ethnicities = append(ethnicities, models.StringFacetCount{Value: value.String, Count: count})
+		}
+	}
+
+	// Hair color facet
+	hairSQL := fmt.Sprintf(`
+		WITH filtered_performers AS (%s)
+		SELECT p.hair_color as value, COUNT(*) as count
+		FROM filtered_performers fp
+		INNER JOIN performers p ON fp.id = p.id
+		WHERE p.hair_color IS NOT NULL AND p.hair_color != ''
+		GROUP BY p.hair_color
+		ORDER BY count DESC
+		LIMIT ?
+	`, baseSQL)
+
+	hairRows, err := dbWrapper.Queryx(ctx, hairSQL, args...)
+	if err != nil {
+		return fmt.Errorf("hair_color facet: %w", err)
+	}
+	defer hairRows.Close()
+
+	var hairColors []models.StringFacetCount
+	for hairRows.Next() {
+		var value stdsql.NullString
+		var count int
+		if err := hairRows.Scan(&value, &count); err != nil {
+			return fmt.Errorf("scanning hair_color: %w", err)
+		}
+		if value.Valid {
+			hairColors = append(hairColors, models.StringFacetCount{Value: value.String, Count: count})
+		}
+	}
+
+	// Eye color facet
+	eyeSQL := fmt.Sprintf(`
+		WITH filtered_performers AS (%s)
+		SELECT p.eye_color as value, COUNT(*) as count
+		FROM filtered_performers fp
+		INNER JOIN performers p ON fp.id = p.id
+		WHERE p.eye_color IS NOT NULL AND p.eye_color != ''
+		GROUP BY p.eye_color
+		ORDER BY count DESC
+		LIMIT ?
+	`, baseSQL)
+
+	eyeRows, err := dbWrapper.Queryx(ctx, eyeSQL, args...)
+	if err != nil {
+		return fmt.Errorf("eye_color facet: %w", err)
+	}
+	defer eyeRows.Close()
+
+	var eyeColors []models.StringFacetCount
+	for eyeRows.Next() {
+		var value stdsql.NullString
+		var count int
+		if err := eyeRows.Scan(&value, &count); err != nil {
+			return fmt.Errorf("scanning eye_color: %w", err)
+		}
+		if value.Valid {
+			eyeColors = append(eyeColors, models.StringFacetCount{Value: value.String, Count: count})
+		}
+	}
+
+	mu.Lock()
+	result.Ethnicities = ethnicities
+	result.HairColors = hairColors
+	result.EyeColors = eyeColors
 	mu.Unlock()
 	return nil
 }

--- a/pkg/sqlite/performer_facets_test.go
+++ b/pkg/sqlite/performer_facets_test.go
@@ -206,6 +206,149 @@ func TestPerformerFacets_ReturnsCountries(t *testing.T) {
 	})
 }
 
+func TestPerformerFacets_ReturnsGroups(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		pqb := db.Performer
+
+		facets, err := pqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Groups are derived from performer appearances in scenes that belong to groups,
+		// so may or may not have entries depending on test data
+		for _, g := range facets.Groups {
+			assert.Greater(t, g.Count, 0, "Group count should be positive")
+			assert.NotEmpty(t, g.ID, "Group ID should not be empty")
+			assert.NotEmpty(t, g.Label, "Group label should not be empty")
+		}
+
+		return nil
+	})
+}
+
+func TestPerformerFacets_GroupsWithFilter(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		pqb := db.Performer
+
+		// Filter to performers with a specific tag
+		tagFilter := &models.PerformerFilterType{
+			Tags: &models.HierarchicalMultiCriterionInput{
+				Value:    []string{strconv.Itoa(tagIDs[tagIdxWithPerformer])},
+				Modifier: models.CriterionModifierIncludes,
+			},
+		}
+
+		facets, err := pqb.GetFacets(ctx, tagFilter, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Groups should still be populated (even if empty)
+		assert.NotNil(t, facets.Groups, "Groups should not be nil with filter")
+
+		// All returned groups should have positive counts
+		for _, g := range facets.Groups {
+			assert.Greater(t, g.Count, 0, "Group count should be positive in filtered results")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.5: Test ethnicity facets
+func TestPerformerFacets_ReturnsEthnicities(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		pqb := db.Performer
+
+		facets, err := pqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Ethnicities may or may not have entries depending on test data
+		for _, e := range facets.Ethnicities {
+			assert.Greater(t, e.Count, 0, "Ethnicity count should be positive")
+			assert.NotEmpty(t, e.Value, "Ethnicity value should not be empty")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.5: Test hair color facets
+func TestPerformerFacets_ReturnsHairColors(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		pqb := db.Performer
+
+		facets, err := pqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Hair colors may or may not have entries depending on test data
+		for _, h := range facets.HairColors {
+			assert.Greater(t, h.Count, 0, "Hair color count should be positive")
+			assert.NotEmpty(t, h.Value, "Hair color value should not be empty")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.5: Test eye color facets
+func TestPerformerFacets_ReturnsEyeColors(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		pqb := db.Performer
+
+		facets, err := pqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Eye colors may or may not have entries depending on test data
+		for _, e := range facets.EyeColors {
+			assert.Greater(t, e.Count, 0, "Eye color count should be positive")
+			assert.NotEmpty(t, e.Value, "Eye color value should not be empty")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.5: Test attribute facets with filter
+func TestPerformerFacets_AttributesWithFilter(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		pqb := db.Performer
+
+		// Filter to performers with specific tag
+		tagFilter := &models.PerformerFilterType{
+			Tags: &models.HierarchicalMultiCriterionInput{
+				Value:    []string{strconv.Itoa(tagIDs[tagIdxWithPerformer])},
+				Modifier: models.CriterionModifierIncludes,
+			},
+		}
+
+		facets, err := pqb.GetFacets(ctx, tagFilter, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// All attribute facets should be populated (even if empty)
+		assert.NotNil(t, facets.Ethnicities, "Ethnicities should not be nil with filter")
+		assert.NotNil(t, facets.HairColors, "HairColors should not be nil with filter")
+		assert.NotNil(t, facets.EyeColors, "EyeColors should not be nil with filter")
+
+		return nil
+	})
+}
+
 // Phase 6: Test parallel execution (indirectly - verify all facets return together)
 func TestPerformerFacets_ReturnsAllFacetsInParallel(t *testing.T) {
 	withRollbackTxn(func(ctx context.Context) error {
@@ -220,8 +363,12 @@ func TestPerformerFacets_ReturnsAllFacetsInParallel(t *testing.T) {
 		// All facet types should be populated (not nil)
 		assert.NotNil(t, facets.Tags, "Tags should not be nil")
 		assert.NotNil(t, facets.Studios, "Studios should not be nil")
+		assert.NotNil(t, facets.Groups, "Groups should not be nil")
 		assert.NotNil(t, facets.Genders, "Genders should not be nil")
 		assert.NotNil(t, facets.Countries, "Countries should not be nil")
+		assert.NotNil(t, facets.Ethnicities, "Ethnicities should not be nil")
+		assert.NotNil(t, facets.HairColors, "HairColors should not be nil")
+		assert.NotNil(t, facets.EyeColors, "EyeColors should not be nil")
 		assert.NotNil(t, facets.Circumcised, "Circumcised should not be nil")
 		assert.NotNil(t, facets.Favorite, "Favorite should not be nil")
 		assert.NotNil(t, facets.Ratings, "Ratings should not be nil")

--- a/pkg/sqlite/scene_facets.go
+++ b/pkg/sqlite/scene_facets.go
@@ -67,17 +67,19 @@ func isEmptyFilter(filter *models.SceneFilterType) bool {
 // When no filter is applied, uses optimized "fast path" queries that skip the CTE.
 func (qb *SceneStore) GetFacets(ctx context.Context, sceneFilter *models.SceneFilterType, limit int) (*models.SceneFacets, error) {
 	result := &models.SceneFacets{
-		Tags:          []models.FacetCount{},
-		Performers:    []models.FacetCount{},
-		Studios:       []models.FacetCount{},
-		Groups:        []models.FacetCount{},
-		PerformerTags: []models.FacetCount{},
-		Resolutions:   []models.ResolutionFacetCount{},
-		Orientations:  []models.OrientationFacetCount{},
-		Organized:     []models.BooleanFacetCount{},
-		Interactive:   []models.BooleanFacetCount{},
-		Ratings:       []models.RatingFacetCount{},
-		Captions:      []models.CaptionFacetCount{},
+		Tags:              []models.FacetCount{},
+		Performers:        []models.FacetCount{},
+		Studios:           []models.FacetCount{},
+		Groups:            []models.FacetCount{},
+		PerformerTags:     []models.FacetCount{},
+		Resolutions:       []models.ResolutionFacetCount{},
+		Orientations:      []models.OrientationFacetCount{},
+		Organized:         []models.BooleanFacetCount{},
+		Interactive:       []models.BooleanFacetCount{},
+		HasMarkers:        []models.BooleanFacetCount{},
+		PerformerFavorite: []models.BooleanFacetCount{},
+		Ratings:           []models.RatingFacetCount{},
+		Captions:          []models.CaptionFacetCount{},
 	}
 
 	// Fast path: When no filter is applied, use optimized direct queries
@@ -96,7 +98,7 @@ func (qb *SceneStore) GetFacets(ctx context.Context, sceneFilter *models.SceneFi
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 8) // 8 parallel goroutines
+	errChan := make(chan error, 9) // 9 parallel goroutines
 
 	// All facets run in parallel - no lazy loading
 	// Wall-clock time = slowest query, not sum of queries
@@ -170,6 +172,15 @@ func (qb *SceneStore) GetFacets(ctx context.Context, sceneFilter *models.SceneFi
 		}
 	}()
 
+	// Advanced boolean facets (has_markers, performer_favorite)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := qb.getAdvancedBooleanFacets(ctx, baseSQL, baseArgs, result, &mu); err != nil {
+			errChan <- fmt.Errorf("advanced boolean facets: %w", err)
+		}
+	}()
+
 	wg.Wait()
 	close(errChan)
 
@@ -191,7 +202,7 @@ func (qb *SceneStore) GetFacets(ctx context.Context, sceneFilter *models.SceneFi
 func (qb *SceneStore) getFacetsUnfiltered(ctx context.Context, limit int, result *models.SceneFacets) (*models.SceneFacets, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	errChan := make(chan error, 8)
+	errChan := make(chan error, 9)
 
 	// Tags - direct count on scenes_tags
 	wg.Add(1)
@@ -564,6 +575,77 @@ func (qb *SceneStore) getFacetsUnfiltered(ctx context.Context, limit int, result
 		}
 		mu.Lock()
 		result.Captions = captions
+		mu.Unlock()
+	}()
+
+	// Advanced boolean facets (has_markers, performer_favorite) - unfiltered
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// HasMarkers - count scenes with at least one marker
+		hasMarkersRows, err := dbWrapper.Queryx(ctx, `
+			SELECT 
+				CASE WHEN marker_count > 0 THEN 'true' ELSE 'false' END as has_markers,
+				COUNT(*) as count
+			FROM (
+				SELECT s.id, COUNT(sm.id) as marker_count
+				FROM scenes s
+				LEFT JOIN scene_markers sm ON s.id = sm.scene_id
+				GROUP BY s.id
+			)
+			GROUP BY has_markers
+		`)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered has_markers facet: %w", err)
+			return
+		}
+		defer hasMarkersRows.Close()
+
+		var hasMarkers []models.BooleanFacetCount
+		for hasMarkersRows.Next() {
+			var value string
+			var count int
+			if err := hasMarkersRows.Scan(&value, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered has_markers: %w", err)
+				return
+			}
+			hasMarkers = append(hasMarkers, models.BooleanFacetCount{Value: value == "true", Count: count})
+		}
+
+		// PerformerFavorite - count scenes with at least one favorite performer
+		perfFavRows, err := dbWrapper.Queryx(ctx, `
+			SELECT 
+				CASE WHEN fav_count > 0 THEN 'true' ELSE 'false' END as has_favorite,
+				COUNT(*) as count
+			FROM (
+				SELECT s.id, SUM(CASE WHEN p.favorite = 1 THEN 1 ELSE 0 END) as fav_count
+				FROM scenes s
+				LEFT JOIN performers_scenes ps ON s.id = ps.scene_id
+				LEFT JOIN performers p ON ps.performer_id = p.id
+				GROUP BY s.id
+			)
+			GROUP BY has_favorite
+		`)
+		if err != nil {
+			errChan <- fmt.Errorf("unfiltered performer_favorite facet: %w", err)
+			return
+		}
+		defer perfFavRows.Close()
+
+		var performerFavorite []models.BooleanFacetCount
+		for perfFavRows.Next() {
+			var value string
+			var count int
+			if err := perfFavRows.Scan(&value, &count); err != nil {
+				errChan <- fmt.Errorf("scanning unfiltered performer_favorite: %w", err)
+				return
+			}
+			performerFavorite = append(performerFavorite, models.BooleanFacetCount{Value: value == "true", Count: count})
+		}
+
+		mu.Lock()
+		result.HasMarkers = hasMarkers
+		result.PerformerFavorite = performerFavorite
 		mu.Unlock()
 	}()
 
@@ -1048,4 +1130,79 @@ func (qb *SceneStore) getCaptionsFacet(ctx context.Context, baseSQL string, base
 	mu.Unlock()
 
 	return rows.Err()
+}
+
+// getAdvancedBooleanFacets fetches has_markers and performer_favorite facets
+func (qb *SceneStore) getAdvancedBooleanFacets(ctx context.Context, baseSQL string, baseArgs []interface{}, result *models.SceneFacets, mu *sync.Mutex) error {
+	args := append([]interface{}{}, baseArgs...)
+
+	// HasMarkers - count scenes with at least one marker
+	hasMarkersSQL := fmt.Sprintf(`
+		WITH filtered_scenes AS (%s)
+		SELECT 
+			CASE WHEN marker_count > 0 THEN 'true' ELSE 'false' END as has_markers,
+			COUNT(*) as count
+		FROM (
+			SELECT fs.id, COUNT(sm.id) as marker_count
+			FROM filtered_scenes fs
+			LEFT JOIN scene_markers sm ON fs.id = sm.scene_id
+			GROUP BY fs.id
+		)
+		GROUP BY has_markers
+	`, baseSQL)
+
+	hasMarkersRows, err := dbWrapper.Queryx(ctx, hasMarkersSQL, args...)
+	if err != nil {
+		return fmt.Errorf("error executing has_markers facet query: %w", err)
+	}
+	defer hasMarkersRows.Close()
+
+	var hasMarkers []models.BooleanFacetCount
+	for hasMarkersRows.Next() {
+		var value string
+		var count int
+		if err := hasMarkersRows.Scan(&value, &count); err != nil {
+			return fmt.Errorf("error scanning has_markers row: %w", err)
+		}
+		hasMarkers = append(hasMarkers, models.BooleanFacetCount{Value: value == "true", Count: count})
+	}
+
+	// PerformerFavorite - count scenes with at least one favorite performer
+	perfFavSQL := fmt.Sprintf(`
+		WITH filtered_scenes AS (%s)
+		SELECT 
+			CASE WHEN fav_count > 0 THEN 'true' ELSE 'false' END as has_favorite,
+			COUNT(*) as count
+		FROM (
+			SELECT fs.id, SUM(CASE WHEN p.favorite = 1 THEN 1 ELSE 0 END) as fav_count
+			FROM filtered_scenes fs
+			LEFT JOIN performers_scenes ps ON fs.id = ps.scene_id
+			LEFT JOIN performers p ON ps.performer_id = p.id
+			GROUP BY fs.id
+		)
+		GROUP BY has_favorite
+	`, baseSQL)
+
+	perfFavRows, err := dbWrapper.Queryx(ctx, perfFavSQL, args...)
+	if err != nil {
+		return fmt.Errorf("error executing performer_favorite facet query: %w", err)
+	}
+	defer perfFavRows.Close()
+
+	var performerFavorite []models.BooleanFacetCount
+	for perfFavRows.Next() {
+		var value string
+		var count int
+		if err := perfFavRows.Scan(&value, &count); err != nil {
+			return fmt.Errorf("error scanning performer_favorite row: %w", err)
+		}
+		performerFavorite = append(performerFavorite, models.BooleanFacetCount{Value: value == "true", Count: count})
+	}
+
+	mu.Lock()
+	result.HasMarkers = hasMarkers
+	result.PerformerFavorite = performerFavorite
+	mu.Unlock()
+
+	return nil
 }

--- a/pkg/sqlite/scene_facets_test.go
+++ b/pkg/sqlite/scene_facets_test.go
@@ -335,7 +335,7 @@ func TestSceneFacets_AllFacetsReturnedInParallel(t *testing.T) {
 	withRollbackTxn(func(ctx context.Context) error {
 		sqb := db.Scene
 
-		// Test that all 11 facets are returned in a single call
+		// Test that all 13 facets are returned in a single call
 		facets, err := sqb.GetFacets(ctx, nil, 100)
 		if err != nil {
 			t.Errorf("Error getting facets: %s", err.Error())
@@ -352,8 +352,54 @@ func TestSceneFacets_AllFacetsReturnedInParallel(t *testing.T) {
 		assert.NotNil(t, facets.Orientations, "Orientations should not be nil")
 		assert.NotNil(t, facets.Organized, "Organized should not be nil")
 		assert.NotNil(t, facets.Interactive, "Interactive should not be nil")
+		assert.NotNil(t, facets.HasMarkers, "HasMarkers should not be nil")
+		assert.NotNil(t, facets.PerformerFavorite, "PerformerFavorite should not be nil")
 		assert.NotNil(t, facets.Ratings, "Ratings should not be nil")
 		assert.NotNil(t, facets.Captions, "Captions should not be nil")
+
+		return nil
+	})
+}
+
+// Phase 7.4: Test has_markers facet
+func TestSceneFacets_ReturnsHasMarkers(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		sqb := db.Scene
+
+		facets, err := sqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// HasMarkers should be returned (may have true and false counts)
+		assert.NotNil(t, facets.HasMarkers, "HasMarkers should not be nil")
+
+		for _, hm := range facets.HasMarkers {
+			assert.GreaterOrEqual(t, hm.Count, 0, "HasMarkers count should be non-negative")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.4: Test performer_favorite facet
+func TestSceneFacets_ReturnsPerformerFavorite(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		sqb := db.Scene
+
+		facets, err := sqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// PerformerFavorite should be returned (may have true and false counts)
+		assert.NotNil(t, facets.PerformerFavorite, "PerformerFavorite should not be nil")
+
+		for _, pf := range facets.PerformerFavorite {
+			assert.GreaterOrEqual(t, pf.Count, 0, "PerformerFavorite count should be non-negative")
+		}
 
 		return nil
 	})

--- a/pkg/sqlite/studio_facets.go
+++ b/pkg/sqlite/studio_facets.go
@@ -16,6 +16,7 @@ func (qb *StudioStore) GetFacets(ctx context.Context, studioFilter *models.Studi
 		Tags:     []models.FacetCount{},
 		Parents:  []models.FacetCount{},
 		Favorite: []models.BooleanFacetCount{},
+		Ratings:  []models.RatingFacetCount{},
 	}
 
 	query, err := qb.makeQuery(ctx, studioFilter, nil)
@@ -31,7 +32,7 @@ func (qb *StudioStore) GetFacets(ctx context.Context, studioFilter *models.Studi
 		WITH filtered_studios AS (%s)
 		
 		SELECT * FROM (
-			SELECT 'tag' as facet_type, t.id, t.name as label, NULL as enum_value, COUNT(DISTINCT st.studio_id) as count
+			SELECT 'tag' as facet_type, t.id, t.name as label, NULL as enum_value, NULL as rating_value, COUNT(DISTINCT st.studio_id) as count
 			FROM filtered_studios fs
 			INNER JOIN studios_tags st ON fs.id = st.studio_id
 			INNER JOIN tags t ON st.tag_id = t.id
@@ -43,7 +44,7 @@ func (qb *StudioStore) GetFacets(ctx context.Context, studioFilter *models.Studi
 		UNION ALL
 		
 		SELECT * FROM (
-			SELECT 'parent' as facet_type, parent.id, parent.name as label, NULL as enum_value, COUNT(DISTINCT child.id) as count
+			SELECT 'parent' as facet_type, parent.id, parent.name as label, NULL as enum_value, NULL as rating_value, COUNT(DISTINCT child.id) as count
 			FROM filtered_studios fs
 			INNER JOIN studios child ON fs.id = child.id
 			INNER JOIN studios parent ON child.parent_id = parent.id
@@ -58,10 +59,24 @@ func (qb *StudioStore) GetFacets(ctx context.Context, studioFilter *models.Studi
 		SELECT * FROM (
 			SELECT 'favorite' as facet_type, 0 as id, '' as label,
 				CASE WHEN s.favorite = 1 THEN 'true' ELSE 'false' END as enum_value,
+				NULL as rating_value,
 				COUNT(*) as count
 			FROM filtered_studios fs
 			INNER JOIN studios s ON fs.id = s.id
 			GROUP BY s.favorite
+		)
+		
+		UNION ALL
+		
+		SELECT * FROM (
+			SELECT 'rating' as facet_type, 0 as id, '' as label, NULL as enum_value,
+				s.rating as rating_value,
+				COUNT(*) as count
+			FROM filtered_studios fs
+			INNER JOIN studios s ON fs.id = s.id
+			WHERE s.rating IS NOT NULL
+			GROUP BY s.rating
+			ORDER BY s.rating DESC
 		)
 	`, baseSQL)
 
@@ -80,9 +95,10 @@ func (qb *StudioStore) GetFacets(ctx context.Context, studioFilter *models.Studi
 		var id int
 		var label stdsql.NullString
 		var enumValue stdsql.NullString
+		var ratingValue stdsql.NullInt64
 		var count int
 
-		if err := rows.Scan(&facetType, &id, &label, &enumValue, &count); err != nil {
+		if err := rows.Scan(&facetType, &id, &label, &enumValue, &ratingValue, &count); err != nil {
 			return nil, fmt.Errorf("error scanning facet row: %w", err)
 		}
 
@@ -104,6 +120,13 @@ func (qb *StudioStore) GetFacets(ctx context.Context, studioFilter *models.Studi
 				result.Favorite = append(result.Favorite, models.BooleanFacetCount{
 					Value: enumValue.String == "true",
 					Count: count,
+				})
+			}
+		case "rating":
+			if ratingValue.Valid {
+				result.Ratings = append(result.Ratings, models.RatingFacetCount{
+					Rating: int(ratingValue.Int64),
+					Count:  count,
 				})
 			}
 		}

--- a/pkg/sqlite/studio_facets_test.go
+++ b/pkg/sqlite/studio_facets_test.go
@@ -150,3 +150,60 @@ func TestStudioFacets_WithParentFilter(t *testing.T) {
 		return nil
 	})
 }
+
+// Phase 7.2: Test ratings facet
+func TestStudioFacets_ReturnsRatings(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		sqb := db.Studio
+
+		facets, err := sqb.GetFacets(ctx, nil, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Ratings should not be nil
+		assert.NotNil(t, facets.Ratings, "Ratings should not be nil")
+
+		// All rating counts should be positive
+		for _, r := range facets.Ratings {
+			assert.Greater(t, r.Count, 0, "Rating count should be positive")
+			assert.Greater(t, r.Rating, 0, "Rating value should be positive")
+			assert.LessOrEqual(t, r.Rating, 100, "Rating value should be <= 100")
+		}
+
+		// Verify ratings are sorted by rating descending
+		for i := 1; i < len(facets.Ratings); i++ {
+			assert.GreaterOrEqual(t, facets.Ratings[i-1].Rating, facets.Ratings[i].Rating,
+				"Ratings should be sorted by rating descending")
+		}
+
+		return nil
+	})
+}
+
+// Phase 7.2: Test ratings with filter
+func TestStudioFacets_RatingsWithFilter(t *testing.T) {
+	withRollbackTxn(func(ctx context.Context) error {
+		sqb := db.Studio
+
+		// Filter to studios with specific tag
+		tagFilter := &models.StudioFilterType{
+			Tags: &models.HierarchicalMultiCriterionInput{
+				Value:    []string{strconv.Itoa(tagIDs[tagIdxWithStudio])},
+				Modifier: models.CriterionModifierIncludes,
+			},
+		}
+
+		facets, err := sqb.GetFacets(ctx, tagFilter, 100)
+		if err != nil {
+			t.Errorf("Error getting facets: %s", err.Error())
+			return nil
+		}
+
+		// Ratings should not be nil even with filter
+		assert.NotNil(t, facets.Ratings, "Ratings should not be nil with filter")
+
+		return nil
+	})
+}

--- a/ui/v2.5/graphql/data/facets.graphql
+++ b/ui/v2.5/graphql/data/facets.graphql
@@ -39,6 +39,11 @@ fragment CaptionFacetCountData on CaptionFacetCount {
   count
 }
 
+fragment StringFacetCountData on StringFacetCount {
+  value
+  count
+}
+
 query SceneFacets($scene_filter: SceneFilterType, $limit: Int) {
   sceneFacets(scene_filter: $scene_filter, limit: $limit) {
     tags {
@@ -93,6 +98,15 @@ query PerformerFacets($performer_filter: PerformerFilterType, $limit: Int) {
     }
     countries {
       ...FacetCountData
+    }
+    ethnicities {
+      ...StringFacetCountData
+    }
+    hair_colors {
+      ...StringFacetCountData
+    }
+    eye_colors {
+      ...StringFacetCountData
     }
     circumcised {
       ...CircumcisedFacetCountData

--- a/ui/v2.5/graphql/data/facets.graphql
+++ b/ui/v2.5/graphql/data/facets.graphql
@@ -85,6 +85,9 @@ query PerformerFacets($performer_filter: PerformerFilterType, $limit: Int) {
     studios {
       ...FacetCountData
     }
+    groups {
+      ...FacetCountData
+    }
     genders {
       ...GenderFacetCountData
     }

--- a/ui/v2.5/graphql/data/facets.graphql
+++ b/ui/v2.5/graphql/data/facets.graphql
@@ -73,6 +73,12 @@ query SceneFacets($scene_filter: SceneFilterType, $limit: Int) {
     interactive {
       ...BooleanFacetCountData
     }
+    has_markers {
+      ...BooleanFacetCountData
+    }
+    performer_favorite {
+      ...BooleanFacetCountData
+    }
     ratings {
       ...RatingFacetCountData
     }
@@ -135,6 +141,12 @@ query GalleryFacets($gallery_filter: GalleryFilterType, $limit: Int) {
       ...FacetCountData
     }
     organized {
+      ...BooleanFacetCountData
+    }
+    has_chapters {
+      ...BooleanFacetCountData
+    }
+    performer_favorite {
       ...BooleanFacetCountData
     }
     ratings {

--- a/ui/v2.5/graphql/data/facets.graphql
+++ b/ui/v2.5/graphql/data/facets.graphql
@@ -137,6 +137,9 @@ query GroupFacets($group_filter: GroupFilterType, $limit: Int) {
     studios {
       ...FacetCountData
     }
+    ratings {
+      ...RatingFacetCountData
+    }
   }
 }
 
@@ -150,6 +153,9 @@ query StudioFacets($studio_filter: StudioFilterType, $limit: Int) {
     }
     favorite {
       ...BooleanFacetCountData
+    }
+    ratings {
+      ...RatingFacetCountData
     }
   }
 }

--- a/ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts
+++ b/ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts
@@ -53,6 +53,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import * as GQL from "src/core/generated-graphql";
 import { LabeledFacetCount, FacetCounts } from "src/extensions/hooks/useFacetCounts";
 
 describe("LabeledFacetCount interface", () => {
@@ -1010,7 +1011,7 @@ describe("Entity-specific FacetCounts builders", () => {
       counts.performers = new Map([["2", { count: 20, label: "Performer" }]]);
       counts.studios = new Map([["3", { count: 30, label: "Studio" }]]);
       counts.booleans.organized = { true: 5, false: 10 };
-      counts.ratings = new Map([["100", { count: 3, label: "100" }]]);
+      counts.ratings = new Map([[100, 3]]);
       
       expect(counts.tags.size).toBe(1);
       expect(counts.performers.size).toBe(1);
@@ -1037,11 +1038,11 @@ describe("Entity-specific FacetCounts builders", () => {
       
       counts.tags = new Map([["1", { count: 10, label: "Tag" }]]);
       counts.studios = new Map([["2", { count: 20, label: "Studio" }]]);
-      counts.genders = new Map([["FEMALE", { count: 30, label: "Female" }]]);
+      counts.genders = new Map([[GQL.GenderEnum.Female, 30]]);
       counts.countries = new Map([["US", { count: 40, label: "US" }]]);
-      counts.circumcised = new Map([["CUT", { count: 5, label: "Cut" }]]);
+      counts.circumcised = new Map([[GQL.CircumisedEnum.Cut, 5]]);
       counts.booleans.favorite = { true: 15, false: 85 };
-      counts.ratings = new Map([["80", { count: 10, label: "80" }]]);
+      counts.ratings = new Map([[80, 10]]);
       
       expect(counts.tags.size).toBe(1);
       expect(counts.studios.size).toBe(1);

--- a/ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts
+++ b/ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts
@@ -92,6 +92,9 @@ describe("FacetCounts interface", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map<string, LabeledFacetCount>(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map(),
       captions: new Map(),
@@ -132,6 +135,9 @@ describe("FacetCounts interface", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map(),
       captions: new Map(),
@@ -483,6 +489,9 @@ describe("State update patterns", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map([[100, 20]]),
       captions: new Map(),
@@ -535,6 +544,9 @@ describe("State update patterns", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map(),
       captions: new Map(), // Empty before update
@@ -591,6 +603,9 @@ describe("State update patterns", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map(),
       captions: new Map(),
@@ -626,6 +641,9 @@ describe("State update patterns", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map(),
       captions: new Map(), // Empty
@@ -769,6 +787,9 @@ describe("Cache serialization", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map([[100, 10], [80, 20]]),
       captions: new Map([["en", 500]]),
@@ -976,6 +997,9 @@ describe("Entity-specific FacetCounts builders", () => {
       orientations: new Map(),
       genders: new Map(),
       countries: new Map(),
+      ethnicities: new Map(),
+      hairColors: new Map(),
+      eyeColors: new Map(),
       circumcised: new Map(),
       ratings: new Map(),
       captions: new Map(),
@@ -1058,10 +1082,46 @@ describe("Entity-specific FacetCounts builders", () => {
       
       // These should remain empty for performer facets
       expect(counts.performers.size).toBe(0);  // Performers don't have performer facets
-      expect(counts.groups.size).toBe(0);
       expect(counts.performerTags.size).toBe(0);
       expect(counts.resolutions.size).toBe(0);
       expect(counts.booleans.organized).toEqual({ true: 0, false: 0 });
+    });
+
+    it("should populate groups facet (Phase 7.3)", () => {
+      const counts = createEmptyFacetCounts();
+      
+      counts.groups = new Map([
+        ["1", { count: 25, label: "Group A" }],
+        ["2", { count: 15, label: "Group B" }],
+      ]);
+      
+      expect(counts.groups.size).toBe(2);
+      expect(counts.groups.get("1")?.count).toBe(25);
+      expect(counts.groups.get("1")?.label).toBe("Group A");
+    });
+
+    it("should populate ethnicity, hair color, eye color facets (Phase 7.5)", () => {
+      const counts = createEmptyFacetCounts();
+      
+      counts.ethnicities = new Map([
+        ["Caucasian", 100],
+        ["Asian", 50],
+      ]);
+      counts.hairColors = new Map([
+        ["Blonde", 80],
+        ["Brunette", 120],
+      ]);
+      counts.eyeColors = new Map([
+        ["Blue", 60],
+        ["Brown", 90],
+      ]);
+      
+      expect(counts.ethnicities.size).toBe(2);
+      expect(counts.ethnicities.get("Caucasian")).toBe(100);
+      expect(counts.hairColors.size).toBe(2);
+      expect(counts.hairColors.get("Blonde")).toBe(80);
+      expect(counts.eyeColors.size).toBe(2);
+      expect(counts.eyeColors.get("Blue")).toBe(60);
     });
   });
 

--- a/ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts
+++ b/ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts
@@ -101,6 +101,9 @@ describe("FacetCounts interface", () => {
       booleans: {
         organized: { true: 0, false: 0 },
         interactive: { true: 0, false: 0 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 0, false: 0 },
       },
       parents: new Map<string, LabeledFacetCount>(),
@@ -144,6 +147,9 @@ describe("FacetCounts interface", () => {
       booleans: {
         organized: { true: 10, false: 90 },
         interactive: { true: 5, false: 95 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 20, false: 80 },
       },
       parents: new Map(),
@@ -498,6 +504,9 @@ describe("State update patterns", () => {
       booleans: {
         organized: { true: 10, false: 90 },
         interactive: { true: 5, false: 95 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 0, false: 0 },
       },
       parents: new Map(),
@@ -553,6 +562,9 @@ describe("State update patterns", () => {
       booleans: {
         organized: { true: 0, false: 0 },
         interactive: { true: 0, false: 0 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 0, false: 0 },
       },
       parents: new Map(),
@@ -612,6 +624,9 @@ describe("State update patterns", () => {
       booleans: {
         organized: { true: 0, false: 0 },
         interactive: { true: 0, false: 0 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 0, false: 0 },
       },
       parents: new Map(),
@@ -650,6 +665,9 @@ describe("State update patterns", () => {
       booleans: {
         organized: { true: 0, false: 0 },
         interactive: { true: 0, false: 0 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 0, false: 0 },
       },
       parents: new Map(),
@@ -796,6 +814,9 @@ describe("Cache serialization", () => {
       booleans: {
         organized: { true: 100, false: 900 },
         interactive: { true: 10, false: 990 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 0, false: 0 },
       },
       parents: new Map(),
@@ -1006,6 +1027,9 @@ describe("Entity-specific FacetCounts builders", () => {
       booleans: {
         organized: { true: 0, false: 0 },
         interactive: { true: 0, false: 0 },
+        hasMarkers: { true: 0, false: 0 },
+        performerFavorite: { true: 0, false: 0 },
+        hasChapters: { true: 0, false: 0 },
         favorite: { true: 0, false: 0 },
       },
       parents: new Map(),

--- a/ui/v2.5/src/extensions/docs/CHANGELOG.md
+++ b/ui/v2.5/src/extensions/docs/CHANGELOG.md
@@ -19,10 +19,17 @@ This document tracks what has been added/modified from the upstream Stash codeba
   - Counts shown match actual filter results (no more misleading counts)
   - 21 new tests for rating facet functionality
 
+- **Group & Studio Ratings Facets (Phase 7.2)**: Added ratings facet to Groups and Studios
+  - Groups now return rating counts in facets (parallel execution)
+  - Studios now return rating counts in facets (UNION ALL query)
+  - Frontend hooks updated to process ratings for both entity types
+  - 4 new backend tests for Group/Studio ratings
+
 ### Changed
 - `RatingFilter.tsx` - Complete rewrite with bucket-based UX, added `totalCount` prop
 - All list pages now pass `totalCount` to rating filter
-- Test count: 88 → 109 tests
+- `useFacetCounts.ts` - `buildGroupFacetCounts` and `buildStudioFacetCounts` now include ratings
+- Test count: 88 → 109 tests (frontend)
 
 ---
 

--- a/ui/v2.5/src/extensions/docs/FACETS-EXTENSION-PLAN.md
+++ b/ui/v2.5/src/extensions/docs/FACETS-EXTENSION-PLAN.md
@@ -117,31 +117,50 @@ const ratingCandidates = useMemo(() => {
 
 ---
 
-### Phase 7.2: Add Group & Studio Ratings Facets
+### Phase 7.2: Add Group & Studio Ratings Facets ✅ COMPLETE
 
 **Goal**: Add `ratings` facet to groups and studios (consistent with other entities)
 
-**Backend Changes**:
+**Status**: ✅ Completed - Groups and Studios now have ratings facets
 
-#### 1. Update `graphql/schema/types/facets.graphql`
+**Changes Made**:
+
+#### Backend
+- **`graphql/schema/types/facets.graphql`**: Added `ratings: [RatingFacetCount!]!` to GroupFacetsResult and StudioFacetsResult
+- **`pkg/models/facets.go`**: Added `Ratings []RatingFacetCount` to GroupFacets and StudioFacets structs
+- **`pkg/sqlite/group_facets.go`**: Added `getRatingsFacet` function and parallel execution for ratings
+- **`pkg/sqlite/studio_facets.go`**: Added ratings to UNION ALL query
+- **`internal/api/resolver_query_facets.go`**: Added `Ratings: convertRatingFacetCounts(f.Ratings)` to converters
+
+#### Frontend
+- **`ui/v2.5/graphql/data/facets.graphql`**: Added `ratings { ...RatingFacetCountData }` to GroupFacets and StudioFacets queries
+- **`ui/v2.5/src/extensions/hooks/useFacetCounts.ts`**: Updated `buildGroupFacetCounts` and `buildStudioFacetCounts` to use `toRatingMap(facets.ratings)`
+
+#### Tests
+- **`pkg/sqlite/group_facets_test.go`**: Added `TestGroupFacets_ReturnsRatings` and `TestGroupFacets_RatingsWithFilter`
+- **`pkg/sqlite/studio_facets_test.go`**: Added `TestStudioFacets_ReturnsRatings` and `TestStudioFacets_RatingsWithFilter`
+
+**Implementation Details**:
+
+#### 1. GraphQL Schema Update
 
 ```graphql
 type GroupFacetsResult {
   tags: [FacetCount!]!
   performers: [FacetCount!]!
   studios: [FacetCount!]!
-  ratings: [RatingFacetCount!]!  # ADD
+  ratings: [RatingFacetCount!]!
 }
 
 type StudioFacetsResult {
   tags: [FacetCount!]!
   parents: [FacetCount!]!
   favorite: [BooleanFacetCount!]!
-  ratings: [RatingFacetCount!]!  # ADD
+  ratings: [RatingFacetCount!]!
 }
 ```
 
-#### 2. Update `pkg/models/facets.go`
+#### 2. Go Models Update
 
 ```go
 type GroupFacets struct {

--- a/ui/v2.5/src/extensions/docs/FACETS-EXTENSION-PLAN.md
+++ b/ui/v2.5/src/extensions/docs/FACETS-EXTENSION-PLAN.md
@@ -44,23 +44,23 @@ This document outlines the plan for extending facet counts support to additional
 
 ### Priority 2: High-Value New Facets
 
-| Entity | Facet | Complexity | Rationale |
-|--------|-------|:----------:|-----------|
-| **Group** | `ratings` | Low | Simple join on groups.rating |
-| **Studio** | `ratings` | Low | Simple join on studios.rating |
-| **Performer** | `groups` | Medium | 3-way join: groups → groups_scenes → performers_scenes |
-| **Scene** | `performer_favorite` | Medium | Join performers_scenes → performers.favorite |
-| **Gallery** | `performer_favorite` | Medium | Join performers_galleries → performers.favorite |
+| Entity | Facet | Complexity | Rationale | Status |
+|--------|-------|:----------:|-----------|--------|
+| **Group** | `ratings` | Low | Simple join on groups.rating | ✅ Phase 7.2 |
+| **Studio** | `ratings` | Low | Simple join on studios.rating | ✅ Phase 7.2 |
+| **Performer** | `groups` | Medium | 3-way join: groups → groups_scenes → performers_scenes | ✅ Phase 7.3 |
+| **Scene** | `performer_favorite` | Medium | Join performers_scenes → performers.favorite | ✅ Phase 7.4 |
+| **Gallery** | `performer_favorite` | Medium | Join performers_galleries → performers.favorite | ✅ Phase 7.4 |
 
 ### Priority 3: Medium-Value New Facets
 
-| Entity | Facet | Complexity | Rationale |
-|--------|-------|:----------:|-----------|
-| Scene | `has_markers` | Low | EXISTS check on scene_markers table |
-| Gallery | `has_chapters` | Low | EXISTS check on gallery_chapters table |
-| Performer | `ethnicity` | Low | Direct field, string-based |
-| Performer | `hair_color` | Low | Direct field, string-based |
-| Performer | `eye_color` | Low | Direct field, string-based |
+| Entity | Facet | Complexity | Rationale | Status |
+|--------|-------|:----------:|-----------|--------|
+| Scene | `has_markers` | Low | EXISTS check on scene_markers table | ✅ Phase 7.4 |
+| Gallery | `has_chapters` | Low | EXISTS check on gallery_chapters table | ✅ Phase 7.4 |
+| Performer | `ethnicity` | Low | Direct field, string-based | ✅ Phase 7.5 |
+| Performer | `hair_color` | Low | Direct field, string-based | ✅ Phase 7.5 |
+| Performer | `eye_color` | Low | Direct field, string-based | ✅ Phase 7.5 |
 
 ### Priority 4: Complex/Low-Value Facets
 
@@ -228,43 +228,56 @@ query StudioFacets {
 
 ---
 
-### Phase 7.3: Add Performer Groups Facet
+### Phase 7.3: Add Performer Groups Facet ✅ COMPLETE
 
 **Goal**: Show which groups performers appear in
 
-**Backend Changes**:
+**Status**: ✅ Completed - Performers now have groups facet showing groups they appear in via scenes
 
-#### 1. Update GraphQL schema
+**Changes Made**:
 
-```graphql
-type PerformerFacetsResult {
-  # ... existing fields ...
-  groups: [FacetCount!]!  # ADD - groups this performer appears in
-}
-```
+#### Backend
+- **`pkg/models/facets.go`**: Added `Groups []FacetCount` to PerformerFacets struct
+- **`pkg/sqlite/performer_facets.go`**: Added `getGroupsFacet` function with 3-way join (performers → performers_scenes → groups_scenes → groups)
+- **`graphql/schema/types/facets.graphql`**: Added `groups: [FacetCount!]!` to PerformerFacetsResult
+- **`internal/api/types_facets.go`**: Added `Groups []*FacetCount` to PerformerFacetsResult
+- **`internal/api/resolver_query_facets.go`**: Added `Groups: convertFacetCounts(f.Groups)` to convertPerformerFacets
 
-#### 2. Add query to `performer_facets.go`
+#### Frontend
+- **`ui/v2.5/graphql/data/facets.graphql`**: Added `groups { ...FacetCountData }` to PerformerFacets query
+- **`ui/v2.5/src/extensions/hooks/useFacetCounts.ts`**: Updated `buildPerformerFacetCounts` to use `toMap(facets.groups ?? [])`
 
-```sql
--- Groups containing performer (via groups_scenes → performers_scenes)
-SELECT g.id, g.name, COUNT(DISTINCT gs.group_id) as count
-FROM performers p
-JOIN performers_scenes ps ON p.id = ps.performer_id
-JOIN groups_scenes gs ON ps.scene_id = gs.scene_id
-JOIN groups g ON gs.group_id = g.id
--- Apply filter CTE here
-GROUP BY g.id, g.name
-ORDER BY count DESC
-LIMIT 100
-```
+#### Tests
+- **`pkg/sqlite/performer_facets_test.go`**: Added `TestPerformerFacets_ReturnsGroups` and `TestPerformerFacets_GroupsWithFilter`
 
 **Estimated effort**: 4-6 hours
 
 ---
 
-### Phase 7.4: Add Boolean Facets (performer_favorite, has_markers, has_chapters)
+### Phase 7.4: Add Boolean Facets (performer_favorite, has_markers, has_chapters) ✅ COMPLETE
 
 **Goal**: Add boolean facets for common filter options
+
+**Status**: ✅ Completed - Scenes have has_markers and performer_favorite; Galleries have has_chapters and performer_favorite
+
+**Changes Made**:
+
+#### Backend
+- **`pkg/models/facets.go`**: Added `HasMarkers`, `PerformerFavorite` to SceneFacets; Added `HasChapters`, `PerformerFavorite` to GalleryFacets
+- **`pkg/sqlite/scene_facets.go`**: Added `getAdvancedBooleanFacets` function for has_markers and performer_favorite
+- **`pkg/sqlite/gallery_facets.go`**: Added `getAdvancedBooleanFacets` function for has_chapters and performer_favorite
+- **`graphql/schema/types/facets.graphql`**: Added `has_markers`, `performer_favorite` to SceneFacetsResult; Added `has_chapters`, `performer_favorite` to GalleryFacetsResult
+- **`internal/api/types_facets.go`**: Added corresponding fields to SceneFacetsResult and GalleryFacetsResult
+- **`internal/api/resolver_query_facets.go`**: Added conversion for new boolean facets
+
+#### Frontend
+- **`ui/v2.5/graphql/data/facets.graphql`**: Added new boolean facet fields to SceneFacets and GalleryFacets queries
+- **`ui/v2.5/src/extensions/hooks/useFacetCounts.ts`**: Updated FacetCounts interface and builders with new booleans (hasMarkers, performerFavorite, hasChapters)
+
+#### Tests
+- **`pkg/sqlite/scene_facets_test.go`**: Added `TestSceneFacets_ReturnsHasMarkers` and `TestSceneFacets_ReturnsPerformerFavorite`
+- **`pkg/sqlite/gallery_facets_test.go`**: Added `TestGalleryFacets_ReturnsHasChapters` and `TestGalleryFacets_ReturnsPerformerFavorite`
+- **`ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts`**: Updated all FacetCounts test structures with new boolean fields
 
 #### Scene `performer_favorite`
 
@@ -309,13 +322,29 @@ GROUP BY has_chapters
 
 ---
 
-### Phase 7.5: Add Performer Attribute Facets
+### Phase 7.5: Add Performer Attribute Facets ✅ COMPLETE
 
 **Goal**: Add facets for performer physical attributes
 
-#### Ethnicity, Hair Color, Eye Color
+**Status**: ✅ Completed - Performers now have ethnicity, hair_color, and eye_color facets
 
-These are simple string fields, so the queries are straightforward:
+**Changes Made**:
+
+#### Backend
+- **`pkg/models/facets.go`**: Added `StringFacetCount` type; Added `Ethnicities`, `HairColors`, `EyeColors` to PerformerFacets
+- **`pkg/sqlite/performer_facets.go`**: Added `getAttributeFacets` function with queries for ethnicity, hair_color, eye_color
+- **`graphql/schema/types/facets.graphql`**: Added `StringFacetCount` type; Added `ethnicities`, `hair_colors`, `eye_colors` to PerformerFacetsResult
+- **`internal/api/types_facets.go`**: Added `StringFacetCount` type; Added fields to PerformerFacetsResult
+- **`internal/api/resolver_query_facets.go`**: Added `convertStringFacetCounts` helper; Added conversion for new attributes
+
+#### Frontend
+- **`ui/v2.5/graphql/data/facets.graphql`**: Added `StringFacetCountData` fragment; Added `ethnicities`, `hair_colors`, `eye_colors` to PerformerFacets query
+- **`ui/v2.5/src/extensions/hooks/useFacetCounts.ts`**: Added `ethnicities`, `hairColors`, `eyeColors` Maps to FacetCounts interface; Added `toStringMap` helper; Updated all builders
+
+#### Tests
+- **`pkg/sqlite/performer_facets_test.go`**: Added `TestPerformerFacets_ReturnsEthnicities`, `TestPerformerFacets_ReturnsHairColors`, `TestPerformerFacets_ReturnsEyeColors`, `TestPerformerFacets_AttributesWithFilter`
+
+#### SQL Queries Used
 
 ```sql
 -- Ethnicity facet
@@ -340,7 +369,7 @@ GROUP BY eye_color
 ORDER BY count DESC
 ```
 
-**New GraphQL types needed**:
+**GraphQL types added**:
 
 ```graphql
 type StringFacetCount {

--- a/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
+++ b/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
@@ -39,6 +39,9 @@ export interface FacetCounts {
   booleans: {
     organized: { true: number; false: number };
     interactive: { true: number; false: number };
+    hasMarkers: { true: number; false: number };
+    performerFavorite: { true: number; false: number };
+    hasChapters: { true: number; false: number };
     favorite: { true: number; false: number };
   };
   parents: Map<string, LabeledFacetCount>;
@@ -70,6 +73,9 @@ function createEmptyCounts(): FacetCounts {
     booleans: {
       organized: { true: 0, false: 0 },
       interactive: { true: 0, false: 0 },
+      hasMarkers: { true: 0, false: 0 },
+      performerFavorite: { true: 0, false: 0 },
+      hasChapters: { true: 0, false: 0 },
       favorite: { true: 0, false: 0 },
     },
     parents: new Map<string, LabeledFacetCount>(),
@@ -127,6 +133,9 @@ interface SerializedFacetCounts {
   booleans: {
     organized: { true: number; false: number };
     interactive: { true: number; false: number };
+    hasMarkers: { true: number; false: number };
+    performerFavorite: { true: number; false: number };
+    hasChapters: { true: number; false: number };
     favorite: { true: number; false: number };
   };
   parents: [string, LabeledFacetCount][];
@@ -438,6 +447,9 @@ function buildSceneFacetCounts(facets: NonNullable<GQL.SceneFacetsQuery['sceneFa
     booleans: {
       organized: toBooleanCounts(facets.organized),
       interactive: toBooleanCounts(facets.interactive),
+      hasMarkers: toBooleanCounts(facets.has_markers ?? []),
+      performerFavorite: toBooleanCounts(facets.performer_favorite ?? []),
+      hasChapters: { true: 0, false: 0 },
       favorite: { true: 0, false: 0 },
     },
     parents: new Map(),
@@ -466,6 +478,9 @@ function buildGalleryFacetCounts(facets: NonNullable<GQL.GalleryFacetsQuery['gal
     booleans: {
       organized: toBooleanCounts(facets.organized),
       interactive: { true: 0, false: 0 },
+      hasMarkers: { true: 0, false: 0 },
+      performerFavorite: toBooleanCounts(facets.performer_favorite ?? []),
+      hasChapters: toBooleanCounts(facets.has_chapters ?? []),
       favorite: { true: 0, false: 0 },
     },
     parents: new Map(),
@@ -494,6 +509,9 @@ function buildPerformerFacetCounts(facets: NonNullable<GQL.PerformerFacetsQuery[
     booleans: {
       organized: { true: 0, false: 0 },
       interactive: { true: 0, false: 0 },
+      hasMarkers: { true: 0, false: 0 },
+      performerFavorite: { true: 0, false: 0 },
+      hasChapters: { true: 0, false: 0 },
       favorite: toBooleanCounts(facets.favorite),
     },
     parents: new Map(),
@@ -522,6 +540,9 @@ function buildGroupFacetCounts(facets: NonNullable<GQL.GroupFacetsQuery['groupFa
     booleans: {
       organized: { true: 0, false: 0 },
       interactive: { true: 0, false: 0 },
+      hasMarkers: { true: 0, false: 0 },
+      performerFavorite: { true: 0, false: 0 },
+      hasChapters: { true: 0, false: 0 },
       favorite: { true: 0, false: 0 },
     },
     parents: new Map(),
@@ -550,6 +571,9 @@ function buildStudioFacetCounts(facets: NonNullable<GQL.StudioFacetsQuery['studi
     booleans: {
       organized: { true: 0, false: 0 },
       interactive: { true: 0, false: 0 },
+      hasMarkers: { true: 0, false: 0 },
+      performerFavorite: { true: 0, false: 0 },
+      hasChapters: { true: 0, false: 0 },
       favorite: toBooleanCounts(facets.favorite),
     },
     parents: toMap(facets.parents),
@@ -578,6 +602,9 @@ function buildTagFacetCounts(facets: NonNullable<GQL.TagFacetsQuery['tagFacets']
     booleans: {
       organized: { true: 0, false: 0 },
       interactive: { true: 0, false: 0 },
+      hasMarkers: { true: 0, false: 0 },
+      performerFavorite: { true: 0, false: 0 },
+      hasChapters: { true: 0, false: 0 },
       favorite: toBooleanCounts(facets.favorite),
     },
     parents: toMap(facets.parents),

--- a/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
+++ b/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
@@ -483,7 +483,7 @@ function buildGroupFacetCounts(facets: NonNullable<GQL.GroupFacetsQuery['groupFa
     genders: new Map(),
     countries: new Map(),
     circumcised: new Map(),
-    ratings: new Map(),
+    ratings: toRatingMap(facets.ratings),
     captions: new Map(),
     booleans: {
       organized: { true: 0, false: 0 },
@@ -508,7 +508,7 @@ function buildStudioFacetCounts(facets: NonNullable<GQL.StudioFacetsQuery['studi
     genders: new Map(),
     countries: new Map(),
     circumcised: new Map(),
-    ratings: new Map(),
+    ratings: toRatingMap(facets.ratings),
     captions: new Map(),
     booleans: {
       organized: { true: 0, false: 0 },

--- a/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
+++ b/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
@@ -30,6 +30,9 @@ export interface FacetCounts {
   orientations: Map<GQL.OrientationEnum, number>;
   genders: Map<GQL.GenderEnum, number>;
   countries: Map<string, LabeledFacetCount>;
+  ethnicities: Map<string, number>;
+  hairColors: Map<string, number>;
+  eyeColors: Map<string, number>;
   circumcised: Map<GQL.CircumisedEnum, number>;
   ratings: Map<number, number>;
   captions: Map<string, number>;
@@ -58,6 +61,9 @@ function createEmptyCounts(): FacetCounts {
     orientations: new Map<GQL.OrientationEnum, number>(),
     genders: new Map<GQL.GenderEnum, number>(),
     countries: new Map<string, LabeledFacetCount>(),
+    ethnicities: new Map<string, number>(),
+    hairColors: new Map<string, number>(),
+    eyeColors: new Map<string, number>(),
     circumcised: new Map<GQL.CircumisedEnum, number>(),
     ratings: new Map<number, number>(),
     captions: new Map<string, number>(),
@@ -112,6 +118,9 @@ interface SerializedFacetCounts {
   orientations: [string, number][];
   genders: [string, number][];
   countries: [string, LabeledFacetCount][];
+  ethnicities?: [string, number][];
+  hairColors?: [string, number][];
+  eyeColors?: [string, number][];
   circumcised: [string, number][];
   ratings: [number, number][];
   captions: [string, number][];
@@ -160,6 +169,9 @@ function serializeCounts(counts: FacetCounts): SerializedFacetCounts {
     orientations: Array.from(counts.orientations.entries()).map(([k, v]) => [k as string, v]),
     genders: Array.from(counts.genders.entries()).map(([k, v]) => [k as string, v]),
     countries: Array.from(counts.countries.entries()),
+    ethnicities: Array.from(counts.ethnicities.entries()),
+    hairColors: Array.from(counts.hairColors.entries()),
+    eyeColors: Array.from(counts.eyeColors.entries()),
     circumcised: Array.from(counts.circumcised.entries()).map(([k, v]) => [k as string, v]),
     ratings: Array.from(counts.ratings.entries()),
     captions: Array.from(counts.captions.entries()),
@@ -181,6 +193,9 @@ function deserializeCounts(data: SerializedFacetCounts): FacetCounts {
     orientations: new Map(data.orientations.map(([k, v]) => [k as GQL.OrientationEnum, v])),
     genders: new Map(data.genders.map(([k, v]) => [k as GQL.GenderEnum, v])),
     countries: new Map(data.countries),
+    ethnicities: new Map(data.ethnicities ?? []),
+    hairColors: new Map(data.hairColors ?? []),
+    eyeColors: new Map(data.eyeColors ?? []),
     circumcised: new Map(data.circumcised.map(([k, v]) => [k as GQL.CircumisedEnum, v])),
     ratings: new Map(data.ratings),
     captions: new Map(data.captions),
@@ -316,6 +331,13 @@ function toMap(counts: { id: string; label: string; count: number }[]): Map<stri
 }
 
 /**
+ * Convert string facet counts to Map (for ethnicity, hair color, eye color)
+ */
+function toStringMap(counts: { value: string; count: number }[]): Map<string, number> {
+  return new Map(counts.map((c) => [c.value, c.count]));
+}
+
+/**
  * Convert resolution facet counts to Map
  */
 function toResolutionMap(
@@ -407,6 +429,9 @@ function buildSceneFacetCounts(facets: NonNullable<GQL.SceneFacetsQuery['sceneFa
     orientations: toOrientationMap(facets.orientations),
     genders: new Map(),
     countries: new Map(),
+    ethnicities: new Map(),
+    hairColors: new Map(),
+    eyeColors: new Map(),
     circumcised: new Map(),
     ratings: toRatingMap(facets.ratings),
     captions: toCaptionMap(facets.captions ?? []),
@@ -432,6 +457,9 @@ function buildGalleryFacetCounts(facets: NonNullable<GQL.GalleryFacetsQuery['gal
     orientations: new Map(),
     genders: new Map(),
     countries: new Map(),
+    ethnicities: new Map(),
+    hairColors: new Map(),
+    eyeColors: new Map(),
     circumcised: new Map(),
     ratings: toRatingMap(facets.ratings),
     captions: new Map(),
@@ -457,6 +485,9 @@ function buildPerformerFacetCounts(facets: NonNullable<GQL.PerformerFacetsQuery[
     orientations: new Map(),
     genders: toGenderMap(facets.genders),
     countries: toMap(facets.countries),
+    ethnicities: toStringMap(facets.ethnicities ?? []),
+    hairColors: toStringMap(facets.hair_colors ?? []),
+    eyeColors: toStringMap(facets.eye_colors ?? []),
     circumcised: toCircumcisedMap(facets.circumcised),
     ratings: toRatingMap(facets.ratings),
     captions: new Map(),
@@ -482,6 +513,9 @@ function buildGroupFacetCounts(facets: NonNullable<GQL.GroupFacetsQuery['groupFa
     orientations: new Map(),
     genders: new Map(),
     countries: new Map(),
+    ethnicities: new Map(),
+    hairColors: new Map(),
+    eyeColors: new Map(),
     circumcised: new Map(),
     ratings: toRatingMap(facets.ratings),
     captions: new Map(),
@@ -507,6 +541,9 @@ function buildStudioFacetCounts(facets: NonNullable<GQL.StudioFacetsQuery['studi
     orientations: new Map(),
     genders: new Map(),
     countries: new Map(),
+    ethnicities: new Map(),
+    hairColors: new Map(),
+    eyeColors: new Map(),
     circumcised: new Map(),
     ratings: toRatingMap(facets.ratings),
     captions: new Map(),
@@ -532,6 +569,9 @@ function buildTagFacetCounts(facets: NonNullable<GQL.TagFacetsQuery['tagFacets']
     orientations: new Map(),
     genders: new Map(),
     countries: new Map(),
+    ethnicities: new Map(),
+    hairColors: new Map(),
+    eyeColors: new Map(),
     circumcised: new Map(),
     ratings: new Map(),
     captions: new Map(),

--- a/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
+++ b/ui/v2.5/src/extensions/hooks/useFacetCounts.ts
@@ -451,7 +451,7 @@ function buildPerformerFacetCounts(facets: NonNullable<GQL.PerformerFacetsQuery[
     tags: toMap(facets.tags),
     performers: new Map(),
     studios: toMap(facets.studios),
-    groups: new Map(),
+    groups: toMap(facets.groups ?? []),
     performerTags: new Map(),
     resolutions: new Map(),
     orientations: new Map(),


### PR DESCRIPTION
# PR: Facet Counts Extension - Phases 7.3, 7.4, 7.5

## Summary

This PR extends the facet counting system with new facets for performers, scenes, and galleries. These additions enable users to see count-based breakdowns for additional filter options in the sidebar.

## What's New

### Phase 7.3: Performer Groups Facet
Shows which groups performers appear in (via their scene appearances).

- **New facet**: `groups` on PerformerFacetsResult
- **Query path**: performers → performers_scenes → groups_scenes → groups
- **Use case**: Filter performers by the groups they've appeared in

### Phase 7.4: Boolean Facets

#### Scene Facets
| Facet | Description |
|-------|-------------|
| `has_markers` | Count of scenes with/without scene markers |
| `performer_favorite` | Count of scenes with/without favorite performers |

#### Gallery Facets
| Facet | Description |
|-------|-------------|
| `has_chapters` | Count of galleries with/without chapters |
| `performer_favorite` | Count of galleries with/without favorite performers |

### Phase 7.5: Performer Attribute Facets
New string-based facets for performer physical attributes:

| Facet | Description |
|-------|-------------|
| `ethnicities` | Count breakdown by ethnicity |
| `hair_colors` | Count breakdown by hair color |
| `eye_colors` | Count breakdown by eye color |

Introduced new `StringFacetCount` GraphQL type for string-valued facets.

---

## Files Changed

### Backend (Go)

| File | Changes |
|------|---------|
| `pkg/models/facets.go` | Added `StringFacetCount` type; Extended `SceneFacets`, `GalleryFacets`, `PerformerFacets` with new fields |
| `pkg/sqlite/performer_facets.go` | Added `getGroupsFacet`, `getAttributeFacets` functions |
| `pkg/sqlite/scene_facets.go` | Added `getAdvancedBooleanFacets` for has_markers, performer_favorite |
| `pkg/sqlite/gallery_facets.go` | Added `getAdvancedBooleanFacets` for has_chapters, performer_favorite |
| `graphql/schema/types/facets.graphql` | Added `StringFacetCount` type; Extended result types with new fields |
| `internal/api/types_facets.go` | Added `StringFacetCount`; Extended result structs |
| `internal/api/resolver_query_facets.go` | Added `convertStringFacetCounts`; Updated converters |

### Frontend (TypeScript)

| File | Changes |
|------|---------|
| `ui/v2.5/graphql/data/facets.graphql` | Added `StringFacetCountData` fragment; Extended queries |
| `ui/v2.5/src/extensions/hooks/useFacetCounts.ts` | Added `ethnicities`, `hairColors`, `eyeColors` Maps; Added `hasMarkers`, `performerFavorite`, `hasChapters` booleans; Added `toStringMap` helper |

### Tests

| File | Tests Added |
|------|-------------|
| `pkg/sqlite/performer_facets_test.go` | `TestPerformerFacets_ReturnsGroups`, `TestPerformerFacets_GroupsWithFilter`, `TestPerformerFacets_ReturnsEthnicities`, `TestPerformerFacets_ReturnsHairColors`, `TestPerformerFacets_ReturnsEyeColors`, `TestPerformerFacets_AttributesWithFilter` |
| `pkg/sqlite/scene_facets_test.go` | `TestSceneFacets_ReturnsHasMarkers`, `TestSceneFacets_ReturnsPerformerFavorite` |
| `pkg/sqlite/gallery_facets_test.go` | `TestGalleryFacets_ReturnsHasChapters`, `TestGalleryFacets_ReturnsPerformerFavorite` |
| `ui/v2.5/src/extensions/__tests__/useFacetCounts.test.ts` | Updated all FacetCounts test structures with new fields; Added performer attribute tests |

### Documentation

| File | Changes |
|------|---------|
| `ui/v2.5/src/extensions/docs/FACETS-EXTENSION-PLAN.md` | Marked Phases 7.3-7.5 as complete; Updated priority matrices |

---

## GraphQL Schema Changes

### New Type
```graphql
type StringFacetCount {
  value: String!
  count: Int!
}
```

### SceneFacetsResult (additions)
```graphql
has_markers: [BooleanFacetCount!]!
performer_favorite: [BooleanFacetCount!]!
```

### GalleryFacetsResult (additions)
```graphql
has_chapters: [BooleanFacetCount!]!
performer_favorite: [BooleanFacetCount!]!
```

### PerformerFacetsResult (additions)
```graphql
groups: [FacetCount!]!
ethnicities: [StringFacetCount!]!
hair_colors: [StringFacetCount!]!
eye_colors: [StringFacetCount!]!
```

---

## SQL Query Examples

### Performer Groups Facet
```sql
SELECT g.id, g.name, COUNT(DISTINCT ps.performer_id) as count
FROM performers_scenes ps
INNER JOIN groups_scenes gs ON ps.scene_id = gs.scene_id
INNER JOIN groups g ON gs.group_id = g.id
GROUP BY g.id
ORDER BY count DESC
```

### Scene has_markers
```sql
SELECT 
  CASE WHEN marker_count > 0 THEN 'true' ELSE 'false' END as has_markers,
  COUNT(*) as count
FROM (
  SELECT s.id, COUNT(sm.id) as marker_count
  FROM scenes s
  LEFT JOIN scene_markers sm ON s.id = sm.scene_id
  GROUP BY s.id
)
GROUP BY has_markers
```

### Performer Attributes
```sql
SELECT ethnicity as value, COUNT(*) as count
FROM performers
WHERE ethnicity IS NOT NULL AND ethnicity != ''
GROUP BY ethnicity
ORDER BY count DESC
```

---

## Testing

### Backend Tests
```bash
go test -v -tags=integration ./pkg/sqlite/... -run Facet
```

### Frontend Tests
```bash
cd ui/v2.5
pnpm test --run extensions
```

---

## Performance Notes

- All new facet queries run in **parallel goroutines** alongside existing facets
- No additional round-trips to the database per facet type
- Unfiltered "fast path" optimizations applied to all new facets
- Index usage verified for performer_scenes and groups_scenes joins

---

## Breaking Changes

None. All changes are additive:
- New fields added to existing GraphQL types
- New properties added to FacetCounts interface (with defaults)
- Existing facets continue to work unchanged

---

## Checklist

- [x] Backend changes in `pkg/sqlite/` 
- [x] GraphQL schema updated
- [x] API types and resolvers updated
- [x] Frontend hook updated
- [x] Backend integration tests added
- [x] Frontend tests updated
- [x] Documentation updated
- [x] No linter errors
- [x] GraphQL codegen regenerated

