### PR TITLE
Feature/dlna activity tracking

### DIFF
--- a/graphql/schema/types/filters.graphql
+++ b/graphql/schema/types/filters.graphql
@@ -606,6 +606,9 @@ input TagFilterType {
   "Filter by autotag ignore value"
   ignore_auto_tag: Boolean
 
+  "Filter by StashID"
+  stash_id_endpoint: StashIDCriterionInput
+
   "Filter by related scenes that meet this criteria"
   scenes_filter: SceneFilterType
   "Filter by related images that meet this criteria"

--- a/internal/dlna/activity.go
+++ b/internal/dlna/activity.go
@@ -1,0 +1,331 @@
+package dlna
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/stashapp/stash/pkg/logger"
+	"github.com/stashapp/stash/pkg/txn"
+)
+
+const (
+	// DefaultSessionTimeout is the time after which a session is considered complete
+	// if no new requests are received.
+	// This is set high (5 minutes) because DLNA clients buffer aggressively and may not
+	// send any HTTP requests for extended periods while the user is still watching.
+	DefaultSessionTimeout = 5 * time.Minute
+
+	// monitorInterval is how often we check for expired sessions.
+	monitorInterval = 10 * time.Second
+)
+
+// ActivityConfig provides configuration options for DLNA activity tracking.
+type ActivityConfig interface {
+	// GetDLNAActivityTrackingEnabled returns true if activity tracking should be enabled.
+	// If not implemented, defaults to true.
+	GetDLNAActivityTrackingEnabled() bool
+
+	// GetMinimumPlayPercent returns the minimum percentage of a video that must be
+	// watched before incrementing the play count. Uses UI setting if available.
+	GetMinimumPlayPercent() int
+}
+
+// SceneActivityWriter provides methods for saving scene activity.
+type SceneActivityWriter interface {
+	SaveActivity(ctx context.Context, sceneID int, resumeTime *float64, playDuration *float64) (bool, error)
+	AddViews(ctx context.Context, sceneID int, dates []time.Time) ([]time.Time, error)
+}
+
+// streamSession represents an active DLNA streaming session.
+type streamSession struct {
+	SceneID        int
+	ClientIP       string
+	StartTime      time.Time
+	LastActivity   time.Time
+	VideoDuration  float64
+	PlayCountAdded bool
+}
+
+// sessionKey generates a unique key for a session based on client IP and scene ID.
+func sessionKey(clientIP string, sceneID int) string {
+	return fmt.Sprintf("%s:%d", clientIP, sceneID)
+}
+
+// percentWatched calculates the estimated percentage of video watched.
+// Uses a time-based approach since DLNA clients buffer aggressively and byte
+// positions don't correlate with actual playback position.
+//
+// The key insight: you cannot have watched more of the video than time has elapsed.
+// If the video is 30 minutes and only 1 minute has passed, maximum watched is ~3.3%.
+func (s *streamSession) percentWatched() float64 {
+	if s.VideoDuration <= 0 {
+		return 0
+	}
+
+	// Calculate elapsed time from session start to last activity
+	elapsed := s.LastActivity.Sub(s.StartTime).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+
+	// Maximum possible percent is based on elapsed time
+	// You can't watch more of the video than time has passed
+	timeBasedPercent := (elapsed / s.VideoDuration) * 100
+
+	// Cap at 100%
+	if timeBasedPercent > 100 {
+		return 100
+	}
+
+	return timeBasedPercent
+}
+
+// estimatedPlayDuration returns the estimated play duration in seconds.
+// Uses elapsed time from session start to last activity, capped by video duration.
+func (s *streamSession) estimatedPlayDuration() float64 {
+	elapsed := s.LastActivity.Sub(s.StartTime).Seconds()
+	if s.VideoDuration > 0 && elapsed > s.VideoDuration {
+		return s.VideoDuration
+	}
+	return elapsed
+}
+
+// estimatedResumeTime calculates the estimated resume time based on elapsed time.
+// Since DLNA clients buffer aggressively, byte positions don't correlate with playback.
+// Instead, we estimate based on how long the session has been active.
+// Returns the time in seconds, or 0 if the video is nearly complete (>=98%).
+func (s *streamSession) estimatedResumeTime() float64 {
+	if s.VideoDuration <= 0 {
+		return 0
+	}
+
+	// Calculate elapsed time from session start
+	elapsed := s.LastActivity.Sub(s.StartTime).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+
+	// If elapsed time exceeds 98% of video duration, reset resume time (matches frontend behavior)
+	if elapsed >= s.VideoDuration*0.98 {
+		return 0
+	}
+
+	// Resume time is approximately where the user was watching
+	// Capped by video duration
+	if elapsed > s.VideoDuration {
+		elapsed = s.VideoDuration
+	}
+
+	return elapsed
+}
+
+// ActivityTracker tracks DLNA streaming activity and saves it to the database.
+type ActivityTracker struct {
+	txnManager     txn.Manager
+	sceneWriter    SceneActivityWriter
+	config         ActivityConfig
+	sessionTimeout time.Duration
+
+	sessions map[string]*streamSession
+	mutex    sync.RWMutex
+
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	wg         sync.WaitGroup
+}
+
+// NewActivityTracker creates a new ActivityTracker.
+func NewActivityTracker(
+	txnManager txn.Manager,
+	sceneWriter SceneActivityWriter,
+	config ActivityConfig,
+) *ActivityTracker {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tracker := &ActivityTracker{
+		txnManager:     txnManager,
+		sceneWriter:    sceneWriter,
+		config:         config,
+		sessionTimeout: DefaultSessionTimeout,
+		sessions:       make(map[string]*streamSession),
+		ctx:            ctx,
+		cancelFunc:     cancel,
+	}
+
+	// Start the session monitor goroutine
+	tracker.wg.Add(1)
+	go tracker.monitorSessions()
+
+	return tracker
+}
+
+// Stop stops the activity tracker and processes any remaining sessions.
+func (t *ActivityTracker) Stop() {
+	t.cancelFunc()
+	t.wg.Wait()
+
+	// Process any remaining sessions
+	t.mutex.Lock()
+	sessions := make([]*streamSession, 0, len(t.sessions))
+	for _, session := range t.sessions {
+		sessions = append(sessions, session)
+	}
+	t.sessions = make(map[string]*streamSession)
+	t.mutex.Unlock()
+
+	for _, session := range sessions {
+		t.processCompletedSession(session)
+	}
+}
+
+// RecordRequest records a streaming request for activity tracking.
+// Each request updates the session's LastActivity time, which is used for
+// time-based tracking of watch progress.
+func (t *ActivityTracker) RecordRequest(sceneID int, clientIP string, videoDuration float64) {
+	if !t.isEnabled() {
+		return
+	}
+
+	key := sessionKey(clientIP, sceneID)
+	now := time.Now()
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	session, exists := t.sessions[key]
+	if !exists {
+		session = &streamSession{
+			SceneID:       sceneID,
+			ClientIP:      clientIP,
+			StartTime:     now,
+			VideoDuration: videoDuration,
+		}
+		t.sessions[key] = session
+		logger.Debugf("[DLNA Activity] New session started: scene=%d, client=%s", sceneID, clientIP)
+	}
+
+	session.LastActivity = now
+}
+
+// monitorSessions periodically checks for expired sessions and processes them.
+func (t *ActivityTracker) monitorSessions() {
+	defer t.wg.Done()
+
+	ticker := time.NewTicker(monitorInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		case <-ticker.C:
+			t.processExpiredSessions()
+		}
+	}
+}
+
+// processExpiredSessions finds and processes sessions that have timed out.
+func (t *ActivityTracker) processExpiredSessions() {
+	now := time.Now()
+	var expiredSessions []*streamSession
+
+	t.mutex.Lock()
+	for key, session := range t.sessions {
+		if now.Sub(session.LastActivity) > t.sessionTimeout {
+			// DLNA clients buffer aggressively - after initial requests, they play from cache.
+			// We assume the user kept watching until the timeout period began.
+			// So the effective "last activity" is (now - timeout), when they actually stopped.
+			//
+			// Example: Session starts at T0, client buffers file in 1s, times out after 30s.
+			// - LastActivity was T0+1s (last HTTP request)
+			// - now is T0+31s (when we detect timeout)
+			// - Actual watch time is likely T0 to T0+31s-30s = T0+1s (no improvement)
+			//
+			// Better approach: assume they watched until halfway through the timeout period.
+			// This is a heuristic that balances "still watching" vs "stopped immediately".
+			session.LastActivity = now.Add(-t.sessionTimeout / 2)
+
+			expiredSessions = append(expiredSessions, session)
+			delete(t.sessions, key)
+		}
+	}
+	t.mutex.Unlock()
+
+	for _, session := range expiredSessions {
+		t.processCompletedSession(session)
+	}
+}
+
+// processCompletedSession saves activity data for a completed streaming session.
+func (t *ActivityTracker) processCompletedSession(session *streamSession) {
+	percentWatched := session.percentWatched()
+	playDuration := session.estimatedPlayDuration()
+	resumeTime := session.estimatedResumeTime()
+
+	logger.Debugf("[DLNA Activity] Session completed: scene=%d, client=%s, percent=%.1f%%, duration=%.1fs, resume=%.1fs",
+		session.SceneID, session.ClientIP, percentWatched, playDuration, resumeTime)
+
+	// Only save if there was meaningful activity (at least 1% watched or 5 seconds)
+	if percentWatched < 1 && playDuration < 5 {
+		logger.Debugf("[DLNA Activity] Session too short, skipping save")
+		return
+	}
+
+	// Skip DB operations if txnManager is nil (for testing)
+	if t.txnManager == nil {
+		logger.Debugf("[DLNA Activity] No transaction manager, skipping DB save")
+		return
+	}
+
+	ctx := context.Background()
+
+	// Save activity (resume time and play duration)
+	if playDuration > 0 || resumeTime > 0 {
+		var resumeTimePtr *float64
+		if resumeTime > 0 {
+			resumeTimePtr = &resumeTime
+		}
+
+		if err := txn.WithTxn(ctx, t.txnManager, func(ctx context.Context) error {
+			_, err := t.sceneWriter.SaveActivity(ctx, session.SceneID, resumeTimePtr, &playDuration)
+			return err
+		}); err != nil {
+			logger.Warnf("[DLNA Activity] Failed to save activity for scene %d: %v", session.SceneID, err)
+		}
+	}
+
+	// Increment play count if threshold met
+	if !session.PlayCountAdded {
+		minPercent := t.getMinimumPlayPercent()
+		if percentWatched >= float64(minPercent) {
+			if err := txn.WithTxn(ctx, t.txnManager, func(ctx context.Context) error {
+				_, err := t.sceneWriter.AddViews(ctx, session.SceneID, []time.Time{time.Now()})
+				return err
+			}); err != nil {
+				logger.Warnf("[DLNA Activity] Failed to increment play count for scene %d: %v", session.SceneID, err)
+			} else {
+				logger.Debugf("[DLNA Activity] Incremented play count for scene %d (%.1f%% watched)",
+					session.SceneID, percentWatched)
+				session.PlayCountAdded = true
+			}
+		}
+	}
+}
+
+// isEnabled returns true if activity tracking is enabled.
+func (t *ActivityTracker) isEnabled() bool {
+	if t.config == nil {
+		return true // Default to enabled
+	}
+	return t.config.GetDLNAActivityTrackingEnabled()
+}
+
+// getMinimumPlayPercent returns the minimum play percentage for incrementing play count.
+func (t *ActivityTracker) getMinimumPlayPercent() int {
+	if t.config == nil {
+		return 0 // Default: any play increments count (matches frontend default)
+	}
+	return t.config.GetMinimumPlayPercent()
+}

--- a/internal/dlna/activity_test.go
+++ b/internal/dlna/activity_test.go
@@ -1,0 +1,432 @@
+package dlna
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockSceneWriter is a mock implementation of SceneActivityWriter
+type mockSceneWriter struct {
+	mu                sync.Mutex
+	saveActivityCalls []saveActivityCall
+	addViewsCalls     []addViewsCall
+}
+
+type saveActivityCall struct {
+	sceneID      int
+	resumeTime   *float64
+	playDuration *float64
+}
+
+type addViewsCall struct {
+	sceneID int
+	dates   []time.Time
+}
+
+func (m *mockSceneWriter) SaveActivity(_ context.Context, sceneID int, resumeTime *float64, playDuration *float64) (bool, error) {
+	m.mu.Lock()
+	m.saveActivityCalls = append(m.saveActivityCalls, saveActivityCall{
+		sceneID:      sceneID,
+		resumeTime:   resumeTime,
+		playDuration: playDuration,
+	})
+	m.mu.Unlock()
+	return true, nil
+}
+
+func (m *mockSceneWriter) AddViews(_ context.Context, sceneID int, dates []time.Time) ([]time.Time, error) {
+	m.mu.Lock()
+	m.addViewsCalls = append(m.addViewsCalls, addViewsCall{
+		sceneID: sceneID,
+		dates:   dates,
+	})
+	m.mu.Unlock()
+	return dates, nil
+}
+
+// mockConfig is a mock implementation of ActivityConfig
+type mockConfig struct {
+	enabled        bool
+	minPlayPercent int
+}
+
+func (c *mockConfig) GetDLNAActivityTrackingEnabled() bool {
+	return c.enabled
+}
+
+func (c *mockConfig) GetMinimumPlayPercent() int {
+	return c.minPlayPercent
+}
+
+func TestStreamSession_PercentWatched(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		startTime     time.Time
+		lastActivity  time.Time
+		videoDuration float64
+		expected      float64
+	}{
+		{
+			name:          "no video duration",
+			startTime:     now.Add(-60 * time.Second),
+			lastActivity:  now,
+			videoDuration: 0,
+			expected:      0,
+		},
+		{
+			name:          "half watched",
+			startTime:     now.Add(-60 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 2 minutes, watched for 1 minute = 50%
+			expected:      50.0,
+		},
+		{
+			name:          "fully watched",
+			startTime:     now.Add(-120 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 2 minutes, watched for 2 minutes = 100%
+			expected:      100.0,
+		},
+		{
+			name:          "quarter watched",
+			startTime:     now.Add(-30 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 2 minutes, watched for 30 seconds = 25%
+			expected:      25.0,
+		},
+		{
+			name:          "elapsed exceeds duration - capped at 100%",
+			startTime:     now.Add(-180 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 2 minutes, but 3 minutes elapsed = capped at 100%
+			expected:      100.0,
+		},
+		{
+			name:          "no elapsed time",
+			startTime:     now,
+			lastActivity:  now,
+			videoDuration: 120.0,
+			expected:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &streamSession{
+				StartTime:     tt.startTime,
+				LastActivity:  tt.lastActivity,
+				VideoDuration: tt.videoDuration,
+			}
+			result := session.percentWatched()
+			assert.InDelta(t, tt.expected, result, 0.01)
+		})
+	}
+}
+
+func TestStreamSession_EstimatedPlayDuration(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		startTime     time.Time
+		lastActivity  time.Time
+		videoDuration float64
+		expected      float64
+	}{
+		{
+			name:          "elapsed less than duration",
+			startTime:     now.Add(-30 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120,
+			expected:      30.0,
+		},
+		{
+			name:          "elapsed exceeds duration - capped",
+			startTime:     now.Add(-180 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120,
+			expected:      120.0,
+		},
+		{
+			name:          "no duration limit",
+			startTime:     now.Add(-300 * time.Second),
+			lastActivity:  now,
+			videoDuration: 0,
+			expected:      300.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &streamSession{
+				StartTime:     tt.startTime,
+				LastActivity:  tt.lastActivity,
+				VideoDuration: tt.videoDuration,
+			}
+			result := session.estimatedPlayDuration()
+			assert.InDelta(t, tt.expected, result, 1.0) // Allow 1 second tolerance
+		})
+	}
+}
+
+func TestStreamSession_EstimatedResumeTime(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		startTime     time.Time
+		lastActivity  time.Time
+		videoDuration float64
+		expected      float64
+	}{
+		{
+			name:          "no elapsed time",
+			startTime:     now,
+			lastActivity:  now,
+			videoDuration: 120.0,
+			expected:      0,
+		},
+		{
+			name:          "half way through",
+			startTime:     now.Add(-60 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 2 minutes, watched for 1 minute = resume at 60s
+			expected:      60.0,
+		},
+		{
+			name:          "quarter way through",
+			startTime:     now.Add(-30 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 2 minutes, watched for 30 seconds = resume at 30s
+			expected:      30.0,
+		},
+		{
+			name:          "98% complete - should reset to 0",
+			startTime:     now.Add(-118 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 98.3% elapsed, should reset
+			expected:      0,
+		},
+		{
+			name:          "100% complete - should reset to 0",
+			startTime:     now.Add(-120 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0,
+			expected:      0,
+		},
+		{
+			name:          "elapsed exceeds duration - capped and reset to 0",
+			startTime:     now.Add(-180 * time.Second),
+			lastActivity:  now,
+			videoDuration: 120.0, // 150% elapsed, capped at 100%, reset to 0
+			expected:      0,
+		},
+		{
+			name:          "no video duration",
+			startTime:     now.Add(-60 * time.Second),
+			lastActivity:  now,
+			videoDuration: 0,
+			expected:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &streamSession{
+				StartTime:     tt.startTime,
+				LastActivity:  tt.lastActivity,
+				VideoDuration: tt.videoDuration,
+			}
+			result := session.estimatedResumeTime()
+			assert.InDelta(t, tt.expected, result, 1.0) // Allow 1 second tolerance
+		})
+	}
+}
+
+func TestSessionKey(t *testing.T) {
+	key := sessionKey("192.168.1.100", 42)
+	assert.Equal(t, "192.168.1.100:42", key)
+}
+
+func TestActivityTracker_RecordRequest(t *testing.T) {
+	config := &mockConfig{enabled: true, minPlayPercent: 50}
+
+	// Create tracker without starting the goroutine (for unit testing)
+	tracker := &ActivityTracker{
+		txnManager:     nil, // Don't need DB for this test
+		sceneWriter:    nil,
+		config:         config,
+		sessionTimeout: DefaultSessionTimeout,
+		sessions:       make(map[string]*streamSession),
+	}
+
+	// Record first request - should create new session
+	tracker.RecordRequest(42, "192.168.1.100", 120.0)
+
+	tracker.mutex.RLock()
+	session := tracker.sessions["192.168.1.100:42"]
+	tracker.mutex.RUnlock()
+
+	assert.NotNil(t, session)
+	assert.Equal(t, 42, session.SceneID)
+	assert.Equal(t, "192.168.1.100", session.ClientIP)
+	assert.Equal(t, 120.0, session.VideoDuration)
+	assert.False(t, session.StartTime.IsZero())
+	assert.False(t, session.LastActivity.IsZero())
+
+	// Record second request - should update LastActivity
+	firstActivity := session.LastActivity
+	time.Sleep(10 * time.Millisecond)
+	tracker.RecordRequest(42, "192.168.1.100", 120.0)
+
+	tracker.mutex.RLock()
+	session = tracker.sessions["192.168.1.100:42"]
+	tracker.mutex.RUnlock()
+
+	assert.True(t, session.LastActivity.After(firstActivity))
+}
+
+func TestActivityTracker_DisabledTracking(t *testing.T) {
+	config := &mockConfig{enabled: false, minPlayPercent: 50}
+
+	// Create tracker without starting the goroutine (for unit testing)
+	tracker := &ActivityTracker{
+		txnManager:     nil,
+		sceneWriter:    nil,
+		config:         config,
+		sessionTimeout: DefaultSessionTimeout,
+		sessions:       make(map[string]*streamSession),
+	}
+
+	// Record request - should be ignored when tracking is disabled
+	tracker.RecordRequest(42, "192.168.1.100", 120.0)
+
+	tracker.mutex.RLock()
+	sessionCount := len(tracker.sessions)
+	tracker.mutex.RUnlock()
+
+	assert.Equal(t, 0, sessionCount)
+}
+
+func TestActivityTracker_SessionExpiration(t *testing.T) {
+	// For this test, we'll test the session expiration logic directly
+	// without the full transaction manager integration
+
+	sceneWriter := &mockSceneWriter{}
+	config := &mockConfig{enabled: true, minPlayPercent: 10}
+
+	// Create a tracker with nil txnManager - we'll test processCompletedSession separately
+	// Here we just verify the session management logic
+	tracker := &ActivityTracker{
+		txnManager:     nil, // Skip DB calls for this test
+		sceneWriter:    sceneWriter,
+		config:         config,
+		sessionTimeout: 100 * time.Millisecond,
+		sessions:       make(map[string]*streamSession),
+	}
+
+	// Manually add a session
+	now := time.Now()
+	tracker.sessions["192.168.1.100:42"] = &streamSession{
+		SceneID:       42,
+		ClientIP:      "192.168.1.100",
+		StartTime:     now.Add(-5 * time.Second),
+		LastActivity:  now.Add(-200 * time.Millisecond), // Expired
+		VideoDuration: 120.0,
+	}
+
+	// Verify session exists
+	assert.Len(t, tracker.sessions, 1)
+
+	// Process expired sessions - this will try to save activity but txnManager is nil
+	// so it will skip the DB calls but still remove the session
+	tracker.processExpiredSessions()
+
+	// Verify session was removed (even though DB calls were skipped)
+	assert.Len(t, tracker.sessions, 0)
+}
+
+func TestActivityTracker_MinimumPlayPercentThreshold(t *testing.T) {
+	// Test the threshold logic without full transaction integration
+	config := &mockConfig{enabled: true, minPlayPercent: 75} // High threshold
+
+	tracker := &ActivityTracker{
+		txnManager:     nil,
+		sceneWriter:    nil,
+		config:         config,
+		sessionTimeout: 50 * time.Millisecond,
+		sessions:       make(map[string]*streamSession),
+	}
+
+	// Test that getMinimumPlayPercent returns the configured value
+	assert.Equal(t, 75, tracker.getMinimumPlayPercent())
+
+	// Create a session with 30% watched (36 seconds of a 120 second video)
+	now := time.Now()
+	session := &streamSession{
+		SceneID:       42,
+		StartTime:     now.Add(-36 * time.Second),
+		LastActivity:  now,
+		VideoDuration: 120.0,
+	}
+
+	// 30% is below 75% threshold
+	percentWatched := session.percentWatched()
+	assert.InDelta(t, 30.0, percentWatched, 0.1)
+	assert.False(t, percentWatched >= float64(tracker.getMinimumPlayPercent()))
+}
+
+func TestActivityTracker_MultipleSessions(t *testing.T) {
+	config := &mockConfig{enabled: true, minPlayPercent: 50}
+
+	// Create tracker without starting the goroutine (for unit testing)
+	tracker := &ActivityTracker{
+		txnManager:     nil,
+		sceneWriter:    nil,
+		config:         config,
+		sessionTimeout: DefaultSessionTimeout,
+		sessions:       make(map[string]*streamSession),
+	}
+
+	// Different clients watching same scene
+	tracker.RecordRequest(42, "192.168.1.100", 120.0)
+	tracker.RecordRequest(42, "192.168.1.101", 120.0)
+
+	// Same client watching different scenes
+	tracker.RecordRequest(43, "192.168.1.100", 180.0)
+
+	tracker.mutex.RLock()
+	assert.Len(t, tracker.sessions, 3)
+	tracker.mutex.RUnlock()
+}
+
+func TestActivityTracker_ShortSessionIgnored(t *testing.T) {
+	// Test that short sessions are ignored
+	// Create a session with only ~0.8% watched (1 second of a 120 second video)
+	now := time.Now()
+	session := &streamSession{
+		SceneID:       42,
+		ClientIP:      "192.168.1.100",
+		StartTime:     now.Add(-1 * time.Second), // Only 1 second
+		LastActivity:  now,
+		VideoDuration: 120.0, // 2 minutes
+	}
+
+	// Verify percent watched is below threshold (1s / 120s = 0.83%)
+	assert.InDelta(t, 0.83, session.percentWatched(), 0.1)
+
+	// Verify play duration is short
+	assert.InDelta(t, 1.0, session.estimatedPlayDuration(), 0.5)
+
+	// Both are below the minimum thresholds (1% and 5 seconds)
+	percentWatched := session.percentWatched()
+	playDuration := session.estimatedPlayDuration()
+	shouldSkip := percentWatched < 1 && playDuration < 5
+	assert.True(t, shouldSkip, "Short session should be skipped")
+}

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -1323,6 +1323,26 @@ func (i *Config) GetUIConfiguration() map[string]interface{} {
 	return i.forKey(UI).Cut(UI).Raw()
 }
 
+// GetMinimumPlayPercent returns the minimum percentage of a video that must be
+// watched before incrementing the play count. Returns 0 if not configured.
+func (i *Config) GetMinimumPlayPercent() int {
+	uiConfig := i.GetUIConfiguration()
+	if uiConfig == nil {
+		return 0
+	}
+	if val, ok := uiConfig["minimumPlayPercent"]; ok {
+		switch v := val.(type) {
+		case int:
+			return v
+		case float64:
+			return int(v)
+		case int64:
+			return int(v)
+		}
+	}
+	return 0
+}
+
 func (i *Config) SetUIConfiguration(v map[string]interface{}) {
 	i.Lock()
 	defer i.Unlock()
@@ -1613,6 +1633,22 @@ func (i *Config) GetDLNAPort() int {
 // GetDLNAPortAsString returns the port to run the DLNA server on as a string.
 func (i *Config) GetDLNAPortAsString() string {
 	return ":" + strconv.Itoa(i.GetDLNAPort())
+}
+
+// GetDLNAActivityTrackingEnabled returns true if DLNA activity tracking is enabled.
+// This uses the same "trackActivity" UI setting that controls frontend play history tracking.
+// When enabled, scenes played via DLNA will have their play count and duration tracked.
+func (i *Config) GetDLNAActivityTrackingEnabled() bool {
+	uiConfig := i.GetUIConfiguration()
+	if uiConfig == nil {
+		return true // Default to enabled
+	}
+	if val, ok := uiConfig["trackActivity"]; ok {
+		if v, ok := val.(bool); ok {
+			return v
+		}
+	}
+	return true // Default to enabled
 }
 
 // GetVideoSortOrder returns the sort order to display videos. If

--- a/internal/manager/init.go
+++ b/internal/manager/init.go
@@ -78,7 +78,7 @@ func Initialize(cfg *config.Config, l *log.Logger) (*Manager, error) {
 	}
 
 	dlnaRepository := dlna.NewRepository(repo)
-	dlnaService := dlna.NewService(dlnaRepository, cfg, sceneServer)
+	dlnaService := dlna.NewService(dlnaRepository, cfg, sceneServer, repo.Scene, cfg.GetMinimumPlayPercent())
 
 	mgr := &Manager{
 		Config: cfg,

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -40,6 +40,8 @@ type TagFilterType struct {
 	ChildCount *IntCriterionInput `json:"child_count"`
 	// Filter by autotag ignore value
 	IgnoreAutoTag *bool `json:"ignore_auto_tag"`
+	// Filter by StashID Endpoint
+	StashIDEndpoint *StashIDCriterionInput `json:"stash_id_endpoint"`
 	// Filter by related scenes that meet this criteria
 	ScenesFilter *SceneFilterType `json:"scenes_filter"`
 	// Filter by related images that meet this criteria

--- a/pkg/scraper/xpath.go
+++ b/pkg/scraper/xpath.go
@@ -261,7 +261,7 @@ func (s *xpathScraper) scrapeImageByImage(ctx context.Context, image *models.Ima
 func (s *xpathScraper) loadURL(ctx context.Context, url string) (*html.Node, error) {
 	r, err := loadURL(ctx, url, s.client, s.config, s.globalConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load URL %q: %w", url, err)
 	}
 
 	ret, err := html.Parse(r)

--- a/pkg/sqlite/setup_test.go
+++ b/pkg/sqlite/setup_test.go
@@ -1688,6 +1688,13 @@ func getTagChildCount(id int) int {
 	return 0
 }
 
+func tagStashID(i int) models.StashID {
+	return models.StashID{
+		StashID:  getTagStringValue(i, "stashid"),
+		Endpoint: getTagStringValue(i, "endpoint"),
+	}
+}
+
 // createTags creates n tags with plain Name and o tags with camel cased NaMe included
 func createTags(ctx context.Context, tqb models.TagReaderWriter, n int, o int) error {
 	const namePlain = "Name"
@@ -1707,6 +1714,12 @@ func createTags(ctx context.Context, tqb models.TagReaderWriter, n int, o int) e
 		tag := models.Tag{
 			Name:          getTagStringValue(index, name),
 			IgnoreAutoTag: getIgnoreAutoTag(i),
+		}
+
+		if (index+1)%5 != 0 {
+			tag.StashIDs = models.NewRelatedStashIDs([]models.StashID{
+				tagStashID(i),
+			})
 		}
 
 		err := tqb.Create(ctx, &tag)

--- a/pkg/sqlite/tag_filter.go
+++ b/pkg/sqlite/tag_filter.go
@@ -84,6 +84,14 @@ func (qb *tagFilterHandler) criterionHandler() criterionHandler {
 		tagHierarchyHandler.ChildrenCriterionHandler(tagFilter.Children),
 		tagHierarchyHandler.ParentCountCriterionHandler(tagFilter.ParentCount),
 		tagHierarchyHandler.ChildCountCriterionHandler(tagFilter.ChildCount),
+
+		&stashIDCriterionHandler{
+			c:                 tagFilter.StashIDEndpoint,
+			stashIDRepository: &tagRepository.stashIDs,
+			stashIDTableAs:    "tag_stash_ids",
+			parentIDCol:       "tags.id",
+		},
+
 		&timestampCriterionHandler{tagFilter.CreatedAt, "tags.created_at", nil},
 		&timestampCriterionHandler{tagFilter.UpdatedAt, "tags.updated_at", nil},
 

--- a/ui/v2.5/src/components/Tagger/context.tsx
+++ b/ui/v2.5/src/components/Tagger/context.tsx
@@ -871,8 +871,7 @@ export const TaggerContext: React.FC = ({ children }) => {
     tag: GQL.ScrapedTag,
     updateInput: GQL.TagUpdateInput
   ) {
-    if (!tag.remote_site_id || !currentSource?.sourceInput.stash_box_endpoint)
-      return;
+    const hasRemoteID = !!tag.remote_site_id;
 
     try {
       await updateTag({
@@ -889,7 +888,10 @@ export const TaggerContext: React.FC = ({ children }) => {
         return {
           ...r,
           tags: r.tags.map((t) => {
-            if (t.remote_site_id === tag.remote_site_id) {
+            if (
+              (hasRemoteID && t.remote_site_id === tag.remote_site_id) ||
+              (!hasRemoteID && t.name === tag.name)
+            ) {
               return {
                 ...t,
                 stored_id: updateInput.id,

--- a/ui/v2.5/src/models/list-filter/tags.ts
+++ b/ui/v2.5/src/models/list-filter/tags.ts
@@ -14,6 +14,7 @@ import {
   ParentTagsCriterionOption,
 } from "./criteria/tags";
 import { FavoriteTagCriterionOption } from "./criteria/favorite";
+import { StashIDCriterionOption } from "./criteria/stash-ids";
 
 const defaultSortBy = "name";
 const sortByOptions = ["name", "random", "scenes_duration"]
@@ -58,6 +59,7 @@ const criterionOptions = [
   createStringCriterionOption("aliases"),
   createStringCriterionOption("description"),
   createBooleanCriterionOption("ignore_auto_tag"),
+  StashIDCriterionOption,
   createMandatoryNumberCriterionOption("scene_count"),
   createMandatoryNumberCriterionOption("image_count"),
   createMandatoryNumberCriterionOption("gallery_count"),


### PR DESCRIPTION
## Summary
Adds time-based activity tracking for scenes played via DLNA, enabling play count, play duration, and resume time tracking similar to the web frontend.

## Changes
- New `ActivityTracker` in `internal/dlna/activity.go`
- Uses existing `trackActivity` UI setting (no new config needed)
- Time-based tracking approach (elapsed session time / video duration)
- 5-minute session timeout to handle aggressive client buffering

## Limitations
This is a heuristic-based approach with known limitations:
- Cannot detect actual playback position (only elapsed time)
- Cannot detect seeking or pause state
- Works best for linear playback

## Testing
- Unit tests added in `activity_test.go`
- Manually tested with Pigasus VR Media Player
